### PR TITLE
Implement 0.5s palm rejection

### DIFF
--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -923,6 +923,11 @@ void ApplePS2SynapticsTouchPad::assignVirtualFinger(int physicalFinger) {
 
 void ApplePS2SynapticsTouchPad::synaptics_parse_hw_state(const UInt8 buf[])
 {
+    
+    // Check if input is disabled via ApplePS2Keyboard request
+    if (ignoreall)
+        return;
+    
     int w = (((buf[0] & 0x30) >> 2) |
              ((buf[0] & 0x04) >> 1) |
              ((buf[3] & 0x04) >> 2));
@@ -1223,8 +1228,14 @@ void ApplePS2SynapticsTouchPad::sendTouchData() {
     
     DEBUG_LOG("synaptics_parse_hw_state lastFingerCount=%d clampedFingerCount=%d", lastFingerCount,  clampedFingerCount);
     
+    // Ignore input for specified time after keyboard usage
     AbsoluteTime timestamp;
     clock_get_uptime(&timestamp);
+    uint64_t timestamp_ns;
+    absolutetime_to_nanoseconds(timestamp, &timestamp_ns);
+    
+    if (timestamp_ns - keytime < maxaftertyping)
+        return;
     
     int transducers_count = 0;
     for(int i = 0; i < SYNAPTICS_MAX_FINGERS; i++) {


### PR DESCRIPTION
Ignore parse hardware input when user disable via keyboard and add 0.5s palm rejection, by ignoring send data to VoodooI2CMT2Simulator.
Based on https://github.com/alexandred/VoodooI2CHID/pull/6