### PR TITLE
Fix Caps Lock LED not working properly.

### DIFF
--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -193,6 +193,8 @@ bool ApplePS2Keyboard::init(OSDictionary * dict)
     _macroMaxTime = 25000000ULL;
     _macroTimer = 0;
 
+    _ignoreCapsLedChagnge = false;
+
     // start out with all keys up
     bzero(_keyBitVector, sizeof(_keyBitVector));
     
@@ -1751,6 +1753,8 @@ bool ApplePS2Keyboard::dispatchKeyboardEventWithPacket(const UInt8* packet)
         // https://github.com/RehabMan/OS-X-Voodoo-PS2-Controller/issues/142#issuecomment-529813842
         if (goingDown || version_major >= 18)
         {
+            DEBUG_LOG("%s: Caps Lock goingDown: 0x%x\n", getName(), goingDown);
+            _ignoreCapsLedChagnge = true;
             clock_get_uptime(&now_abs);
             dispatchKeyboardEventX(adbKeyCode, true, now_abs);
             clock_get_uptime(&now_abs);
@@ -1803,6 +1807,13 @@ void ApplePS2Keyboard::setAlphaLockFeedback(bool locked)
     // It is safe to issue this request from the interrupt/completion context.
     //
 
+
+    DEBUG_LOG("%s: setAlphaLockFeedback locked:0x%x ignore: 0x%x\n", getName(), locked, _ignoreCapsLedChagnge);
+    if (_ignoreCapsLedChagnge)
+    {
+        _ignoreCapsLedChagnge = false;
+        return;
+    }
     _ledState = locked ? (_ledState | kLED_CapsLock):(_ledState & ~kLED_CapsLock);
     setLEDs(_ledState);
 }

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -1808,7 +1808,7 @@ void ApplePS2Keyboard::setAlphaLockFeedback(bool locked)
     //
 
 
-    DEBUG_LOG("%s: setAlphaLockFeedback locked:0x%x ignore: 0x%x\n", getName(), locked, _ignoreCapsLedChagnge);
+    DEBUG_LOG("%s: setAlphaLockFeedback locked:0x%x ignore: 0x%x\n", getName(), locked, _ignoreCapsLedChange);
     if (_ignoreCapsLedChange)
     {
         _ignoreCapsLedChange = false;

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -193,7 +193,7 @@ bool ApplePS2Keyboard::init(OSDictionary * dict)
     _macroMaxTime = 25000000ULL;
     _macroTimer = 0;
 
-    _ignoreCapsLedChagnge = false;
+    _ignoreCapsLedChange = false;
 
     // start out with all keys up
     bzero(_keyBitVector, sizeof(_keyBitVector));
@@ -1754,7 +1754,7 @@ bool ApplePS2Keyboard::dispatchKeyboardEventWithPacket(const UInt8* packet)
         if (goingDown || version_major >= 18)
         {
             DEBUG_LOG("%s: Caps Lock goingDown: 0x%x\n", getName(), goingDown);
-            _ignoreCapsLedChagnge = true;
+            _ignoreCapsLedChange = true;
             clock_get_uptime(&now_abs);
             dispatchKeyboardEventX(adbKeyCode, true, now_abs);
             clock_get_uptime(&now_abs);
@@ -1809,9 +1809,9 @@ void ApplePS2Keyboard::setAlphaLockFeedback(bool locked)
 
 
     DEBUG_LOG("%s: setAlphaLockFeedback locked:0x%x ignore: 0x%x\n", getName(), locked, _ignoreCapsLedChagnge);
-    if (_ignoreCapsLedChagnge)
+    if (_ignoreCapsLedChange)
     {
-        _ignoreCapsLedChagnge = false;
+        _ignoreCapsLedChange = false;
         return;
     }
     _ledState = locked ? (_ledState | kLED_CapsLock):(_ledState & ~kLED_CapsLock);

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -127,6 +127,9 @@ private:
     uint64_t                    _macroMaxTime;
     IOTimerEventSource*         _macroTimer;
     
+    // fix caps lock led
+    bool                        _ignoreCapsLedChagnge;
+
     virtual bool dispatchKeyboardEventWithPacket(const UInt8* packet);
     virtual void setLEDs(UInt8 ledState);
     virtual void setKeyboardEnable(bool enable);

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -128,7 +128,7 @@ private:
     IOTimerEventSource*         _macroTimer;
     
     // fix caps lock led
-    bool                        _ignoreCapsLedChagnge;
+    bool                        _ignoreCapsLedChange;
 
     virtual bool dispatchKeyboardEventWithPacket(const UInt8* packet);
     virtual void setLEDs(UInt8 ledState);


### PR DESCRIPTION
Hi,

#3 fixed the Caps Lock functionality, but the LED still works in a strange way.

The LED is always lighted when the caps lock is pressed and turns off when it is released, just like a blink.

In the log:
```shell
kernel: (kernel) ApplePS2Keyboard: Caps Lock goingDown: 0x1 # pressed
kernel: (kernel) ApplePS2Keyboard: setAlphaLockFeedback locked:0x1 # turn on LED, should be ignored
kernel: (kernel) ApplePS2Keyboard: setAlphaLockFeedback locked:0x1 # This is the true state change.
kernel: (kernel) ApplePS2Keyboard: Caps Lock goingDown: 0x0 #released
kernel: (kernel) ApplePS2Keyboard: setAlphaLockFeedback locked:0x0 # turn off LED, should be ignored
```

The true state change for LED was overridden in the period.

This fix is to ignore the LED changes after caps lock key going down and going up.
It should work for both a long press and a short press when changing caps state and input source.

Note that there seems to be a system bug for Catalina. The caps state LED doesn't work sometimes. You may need to toggle (enable and disable) the option in `Keyboard -> Input Sources -> Use the Caps Lock key to switch ...`.
