### PR TITLE
Add boot arg for resetController()

### DIFF
--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -489,7 +489,10 @@ bool ApplePS2Controller::start(IOService * provider)
   // Reset and clean the 8042 keyboard/mouse controller.
   //
     
-  resetController();
+  PE_parse_boot_argn("ps2rst", &_resetControllerFlag, sizeof(_resetControllerFlag));
+  if (_resetControllerFlag & RESET_CONTROLLER_ON_BOOT) {
+    resetController();
+  }
 
   //
   // Use a spin lock to protect the client async request queue.
@@ -1856,7 +1859,10 @@ void ApplePS2Controller::setPowerStateGated( UInt32 powerState )
         // Reset and clean the 8042 keyboard/mouse controller.
         //
         
-        resetController();
+        if (_resetControllerFlag & RESET_CONTROLLER_ON_WAKEUP)
+        {
+          resetController();
+        }
             
 #endif // FULL_INIT_AFTER_WAKE
             

--- a/VoodooPS2Controller/VoodooPS2Controller.h
+++ b/VoodooPS2Controller/VoodooPS2Controller.h
@@ -169,6 +169,10 @@ struct KeyboardQueueElement
 #define kMergedConfiguration    "Merged Configuration"
 #endif
 
+// ps2rst flags
+#define RESET_CONTROLLER_ON_BOOT 1
+#define RESET_CONTROLLER_ON_WAKEUP 2
+
 class IOACPIPlatformDevice;
 
 enum {
@@ -262,6 +266,8 @@ private:
 #endif
   OSDictionary*            _rmcfCache {nullptr};
   const OSSymbol*          _deliverNotification {nullptr};
+
+  int                      _resetControllerFlag {RESET_CONTROLLER_ON_BOOT | RESET_CONTROLLER_ON_WAKEUP};
 
   virtual PS2InterruptResult _dispatchDriverInterrupt(PS2DeviceType deviceType, UInt8 data);
   virtual void dispatchDriverInterrupt(PS2DeviceType deviceType, UInt8 data);


### PR DESCRIPTION
Add a boot argument 'ps2rst' for the 'resetController()' function. Resolved https://github.com/acidanthera/bugtracker/issues/734.
 - `ps2rst=0` Never reset controller;
 - `ps2rst=1` Reset controller on boot;
 - `ps2rst=2` Reset controller on waking up;
 - Absent or `ps2rst=3`. Reset controller on boot and waking up. This is the default value corresponding to the current behavior in master branch.