### PR TITLE
Added support pressure flag from Voodoo Input to prevent pressure spoofing

### DIFF
--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -1632,6 +1632,7 @@ void ApplePS2SynapticsTouchPad::sendTouchData() {
         transducer.currentCoordinates.width = state.pressure / 2;
         transducer.id = i;
         transducer.secondaryId = i;
+        transducer.supportsPressure = true;
     }
     
     if (transducers_count != clampedFingerCount)


### PR DESCRIPTION
If this PR for VoodooInput is merged, https://github.com/acidanthera/VoodooInput/pull/9, then VoodooPS2 will need to be updated to support the supports pressure flag.

Additionally, VoodooInput submodule will also need to be updated, otherwise VoodooPS2 will fail to build as the out-of-date submodules will not have the new flag,