### PR TITLE
Proposes fix to Synaptics touchpad not working after sleep wake

### DIFF
--- a/VoodooPS2Controller.xcodeproj/project.pbxproj
+++ b/VoodooPS2Controller.xcodeproj/project.pbxproj
@@ -797,7 +797,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				"LLVM_LTO[arch=x86_64]" = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MODULE_VERSION = 2.1.5;
+				MODULE_VERSION = 2.1.6;
 				ONLY_ACTIVE_ARCH = YES;
 				"OTHER_LDFLAGS[arch=x86_64]" = "-dead_strip";
 				PRODUCT_NAME = VoodooPS2Controller;
@@ -849,7 +849,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				"LLVM_LTO[arch=x86_64]" = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MODULE_VERSION = 2.1.5;
+				MODULE_VERSION = 2.1.6;
 				"OTHER_LDFLAGS[arch=x86_64]" = "-dead_strip";
 				PRODUCT_NAME = VoodooPS2Controller;
 				SDKROOT = macosx;

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -525,7 +525,9 @@ enum
     kPS2M_getDisableTouchpad = iokit_vendor_specific_msg(101),   // get disable/enable touchpad (data is bool*)
     kPS2M_notifyKeyPressed = iokit_vendor_specific_msg(102),     // notify of time key pressed (data is PS2KeyInfo*)
     
-    kPS2M_notifyKeyTime = iokit_vendor_specific_msg(110)        // notify of timestamp a non-modifier key was pressed (data is uint64_t*)
+    kPS2M_notifyKeyTime = iokit_vendor_specific_msg(110),        // notify of timestamp a non-modifier key was pressed (data is uint64_t*)
+    
+    kPS2M_resetTouchpad = iokit_vendor_specific_msg(151),        // Force touchpad reset (data is int*)
 };
 
 typedef struct PS2KeyInfo

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -1593,9 +1593,6 @@ bool ApplePS2Keyboard::dispatchKeyboardEventWithPacket(const UInt8* packet)
                     dispatchKeyboardEventX(0x3b, false, now_abs);
                     dispatchKeyboardEventX(0x7f, true, now_abs);
                     dispatchKeyboardEventX(0x7f, false, now_abs);
-                    
-                    int val = 1;
-                    _device->dispatchMessage(kPS2M_resetTouchpad, &val); // Reset touchpad
                 }
             }
             break;

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -142,6 +142,8 @@ private:
     void modifyScreenBrightness(int adbKeyCode, bool goingDown);
     inline bool checkModifierState(UInt16 mask)
         { return mask == (_PS2modifierState & mask); }
+    inline bool checkModifierStateAny(UInt16 mask)
+        { return (_PS2modifierState & mask); }
     
     void loadCustomPS2Map(OSArray* pArray);
     void loadBreaklessPS2(OSDictionary* dict, const char* name);

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -2356,6 +2356,10 @@ void ApplePS2SynapticsTouchPad::setDevicePowerState( UInt32 whatToDo )
             
             // Reset and enable the touchpad.
             initTouchPad();
+            
+            // Send extra kDP_Enable command
+            IOSleep(wakedelay);
+            setTouchPadEnable(true);
             break;
     }
 }
@@ -2396,6 +2400,20 @@ IOReturn ApplePS2SynapticsTouchPad::message(UInt32 type, IOService* provider, vo
             break;
         }
             
+        case kPS2M_resetTouchpad:
+        {
+            int* reqCode = (int*)argument;
+            IOLog("VoodooPS2SynapticsTouchPad::kPS2M_resetTouchpad reqCode: %d\n", *reqCode);
+            if (*reqCode == 1)
+            {
+                ignoreall = false;
+                initTouchPad();
+                IOSleep(wakedelay);
+                setTouchPadEnable(true); // Send extra kDP_Enable
+                updateTouchpadLED();
+            }
+            break;
+        }
         case kPS2M_notifyKeyPressed:
         {
             // just remember last time key pressed... this can be used in


### PR DESCRIPTION
**Changes on this commit:**
+ Added Vendor Specific Message with code **151 (0x97)** to `ApplePS2Device` used to request Trackpad resets from Keypad controller.
- `VoodooPS2Keyboard` now requests a Trackpad reset too when the 3-finger salute (_Ctrl+Alt+Del_) is pressed on the Keypad.
+ Fix: Added an extra `kDP_Enable` command request on `VoodooPS2SynapticsTouchPad` when waking from sleep. This should auto-enable reluctant Synaptics touchpads on wake.
+ Added handling code for resetTouchpad IOkit messages on `VoodooPS2SynapticsTouchPad`, to actually reset and re-enable the device on request.
- Bumped module version to **2.1.6**

**TL;DR:** This commit tries to fix some **Synaptics touchpad devices** not working after waking from sleep. If that doesnt work automatically after a couple of seconds, press **Ctrl+Alt+Del to issue a device reset**. This can be done at any time.

**Dev note:** It may be a good idea to implement the the reset message handling on any other touchpad driver too, this should give users a keyboard combo command to try to recover from non-working scenarios, before giving up and rebooting.