### PR TITLE
Get ACPI notification for brightness keys from GFX0.DD1F/DD02

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ xcuserdata
 xcshareddata
 project.xcworkspace
 VoodooInput
+Lilu.kext

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
     compiler: clang
 
     script:
+      - src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/Lilu/master/Lilu/Scripts/bootstrap.sh) && eval "$src" || exit 1
       - src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/VoodooInput/master/VoodooInput/Scripts/bootstrap.sh) && eval "$src" || exit 1
       - xcodebuild -configuration Debug
       - xcodebuild -configuration Release
@@ -28,6 +29,7 @@ matrix:
     compiler: clang
 
     script:
+      - src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/Lilu/master/Lilu/Scripts/bootstrap.sh) && eval "$src" || exit 1
       - src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/VoodooInput/master/VoodooInput/Scripts/bootstrap.sh) && eval "$src" || exit 1
       - xcodebuild analyze -quiet -scheme VoodooPS2Controller -configuration Debug CLANG_ANALYZER_OUTPUT=plist-html CLANG_ANALYZER_OUTPUT_DIR="$(pwd)/clang-analyze" && [ "$(find clang-analyze -name "*.html")" = "" ]
       - xcodebuild analyze -quiet -scheme VoodooPS2Controller -configuration Release CLANG_ANALYZER_OUTPUT=plist-html CLANG_ANALYZER_OUTPUT_DIR="$(pwd)/clang-analyze" && [ "$(find clang-analyze -name "*.html")" = "" ]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 VoodooPS2 Changelog
 ============================
+#### v2.1.7
+- Added ability for native brightness keys discovery with `Lilu` API, please be aware of this new dependecy and drop SSDT modification to corresponding `_QXX`.
+- Added constants for 11.0 support
+
 #### v2.1.6
 - Upgraded to VoodooInput 1.0.7
 - Fixed swiping desktops when holding a dragged item by improving thumb detection

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The parameters in the formula are configured using `ForceTouchCustomUpThreshold`
 
 ## Installation and compilation
 
+For native brightness keys discovery, `Lilu` is required to probe graphics devices.
+
 For VoodooPS2Trackpad.kext to work multitouch interface engine, named VoodooInput.kext, is required.
 
 - For released binaries a compatible version of VoodooInput.kext is already included in the PlugIns directory.

--- a/VoodooPS2Controller.xcodeproj/project.pbxproj
+++ b/VoodooPS2Controller.xcodeproj/project.pbxproj
@@ -524,7 +524,7 @@
 		84167808161B55B2002C60E6 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = Acidanthera;
 			};
 			buildConfigurationList = 8416780B161B55B2002C60E6 /* Build configuration list for PBXProject "VoodooPS2Controller" */;
@@ -752,6 +752,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++1y";
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
@@ -811,6 +812,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++1y";
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;

--- a/VoodooPS2Controller.xcodeproj/project.pbxproj
+++ b/VoodooPS2Controller.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 				84167814161B55B2002C60E6 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		84167814161B55B2002C60E6 /* Products */ = {
 			isa = PBXGroup;

--- a/VoodooPS2Controller.xcodeproj/project.pbxproj
+++ b/VoodooPS2Controller.xcodeproj/project.pbxproj
@@ -907,6 +907,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/VoodooPS2Controller.kext/Contents/PlugIns";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Lilu.kext/Contents/Resources";
 				INFOPLIST_FILE = "VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -928,6 +929,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/VoodooPS2Controller.kext/Contents/PlugIns";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Lilu.kext/Contents/Resources";
 				INFOPLIST_FILE = "VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",

--- a/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/VoodooPS2Controller.xcscheme
+++ b/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/VoodooPS2Controller.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/VoodooPS2Keyboard.xcscheme
+++ b/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/VoodooPS2Keyboard.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/VoodooPS2Mouse.xcscheme
+++ b/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/VoodooPS2Mouse.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/VoodooPS2Trackpad.xcscheme
+++ b/VoodooPS2Controller.xcodeproj/xcshareddata/xcschemes/VoodooPS2Trackpad.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -159,6 +159,16 @@
 #define kSC_Delete              0x53    // (extended = gray key)
 #define kSC_NumLock             0x45
 
+//
+// ACPI message for brightness keys.
+//
+
+#define kIOACPIMessageBrightnessCycle   0x85    // Cycle Brightness
+#define kIOACPIMessageBrightnessUp      0x86    // Increase Brightness
+#define kIOACPIMessageBrightnessDown    0x87    // Decrease Brightness
+#define kIOACPIMessageBrightnessZero    0x88    // Zero Brightness
+#define kIOACPIMessageBrightnessOff     0x89    // Display Device Off
+
 // name of drivers/services as registered
 
 #define kApplePS2Controller          "ApplePS2Controller"

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -1256,7 +1256,7 @@ UInt8 ApplePS2Controller::readDataPort(PS2DeviceType deviceType)
   //
 
   UInt8  readByte;
-  UInt8  status;
+  UInt8  status         = 0;
   UInt32 timeoutCounter = 20000;    // (timeoutCounter * kDataDelay = 140 ms)
 
   while (1)
@@ -1378,7 +1378,7 @@ UInt8 ApplePS2Controller::readDataPort(PS2DeviceType deviceType,
   bool   firstByteHeld = false;
   UInt8  readByte;
   bool   requestedStream;
-  UInt8  status;
+  UInt8  status         = 0;
   UInt32 timeoutCounter = 10000;    // (timeoutCounter * kDataDelay = 70 ms)
 
   while (1)

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist
@@ -583,6 +583,8 @@
 		<string>8.0.0</string>
 		<key>as.acidanthera.voodoo.driver.PS2Controller</key>
 		<string>${MODULE_VERSION}</string>
+		<key>as.vit9696.Lilu</key>
+		<string>1.2.0</string>
 	</dict>
 	<key>OSBundleRequired</key>
 	<string>Console</string>

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard-Info.plist
@@ -569,6 +569,8 @@
 	</dict>
 	<key>OSBundleLibraries</key>
 	<dict>
+		<key>com.apple.iokit.IOACPIFamily</key>
+		<string>1.0.0d1</string>
 		<key>com.apple.iokit.IOHIDFamily</key>
 		<string>1.0.0b1</string>
 		<key>com.apple.kpi.bsd</key>

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -65,6 +65,11 @@
 #define kMacroTranslation                   "Macro Translation"
 #define kMaxMacroTime                       "MaximumMacroTime"
 
+// Constants for brightness keys
+
+#define kBrightnessDevice                   "BrightnessDevice"
+#define kBrightnessKey                      "BrightnessKey"
+
 // Definitions for Macro Inversion data format
 //REVIEW: This should really be defined as some sort of structure
 #define kIgnoreBytes            2 // first two bytes of macro data are ignored (always 0xffff)
@@ -388,13 +393,16 @@ bool ApplePS2Keyboard::start(IOService * provider)
     // get IOACPIPlatformDevice for Device (PS2K)
     //REVIEW: should really look at the parent chain for IOACPIPlatformDevice instead.
     if ((_gfx = (IOACPIPlatformDevice*)IORegistryEntry::fromPath("IOACPIPlane:/_SB/PCI0@0/GFX0@20000/DD1F@400")) ||
-        (_gfx = (IOACPIPlatformDevice*)IORegistryEntry::fromPath("IOACPIPlane:/_SB/PCI0@0/GFX0@20000/DD02@400"))) {
+        (_gfx = (IOACPIPlatformDevice*)IORegistryEntry::fromPath("IOACPIPlane:/_SB/PCI0@0/GFX0@20000/DD02@400")) ||
+        (_gfx = (IOACPIPlatformDevice*)IORegistryEntry::fromPath("IOACPIPlane:/_SB/PCI0@0/VID@20000/LCD0@400")) ||
+        (_gfx = (IOACPIPlatformDevice*)IORegistryEntry::fromPath("IOACPIPlane:/_SB/PCI0@0/VGA@20000/LCDD@400")) ||
+        (_gfx = (IOACPIPlatformDevice*)IORegistryEntry::fromPath("IOACPIPlane:/_SB/PCI0@0/PEG@1c0004/VID@0/LCD0@110"))) {
         _gfxNotifiers = _gfx->registerInterest(gIOGeneralInterest, _gfxNotification, this);
         if (!_gfxNotifiers) {
             IOLog("ps2br: unable to register interest for GFX notifications\n");
-            setProperty("BrightnessDevice", false);
+            setProperty(kBrightnessDevice, false);
         } else {
-            setProperty("BrightnessDevice", _gfx->getName());
+            setProperty(kBrightnessDevice, _gfx->getName());
         }
     }
 
@@ -1997,7 +2005,7 @@ IOReturn ApplePS2Keyboard::_gfxNotification(void *target, void *refCon, UInt32 m
             }
             if (!self->_gfxKey) {
                 self->_gfxKey = true;
-                self->setProperty("ACPIBrightnessKey", true);
+                self->setProperty(kBrightnessKey, "ACPI");
             }
         } else {
             DEBUG_LOG("%s %s received unknown kIOACPIMessageDeviceNotification\n", self->getName(), provider->getName());

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -443,56 +443,6 @@ bool ApplePS2Keyboard::start(IOService * provider)
             IOLog("ps2br: unable to register interest for GFX notifications\n");
     }
 
-    OSObject* res = 0;
-    if (_gfx) do
-    {
-        // check for brightness methods
-        if (kIOReturnSuccess != _gfx->validateObject("_BCL") || kIOReturnSuccess != _gfx->validateObject("_BCM") || kIOReturnSuccess != _gfx->validateObject("_BQC"))
-        {
-            break;
-        }
-        // methods are there, so now try to collect brightness levels
-        if (kIOReturnSuccess != _gfx->evaluateObject("_BCL", &res))
-        {
-            DEBUG_LOG("ps2br: _BCL returned error\n");
-            break;
-        }
-        OSArray* array = OSDynamicCast(OSArray, res);
-        if (!array)
-        {
-            DEBUG_LOG("ps2br: _BCL returned non-array package\n");
-            break;
-        }
-        int count = array->getCount();
-        if (count < 4)
-        {
-            DEBUG_LOG("ps2br: _BCL returned invalid package\n");
-            break;
-        }
-        _brightnessCount = count;
-        _brightnessLevels = new int[_brightnessCount];
-        if (!_brightnessLevels)
-        {
-            DEBUG_LOG("ps2br: _brightnessLevels new int[] failed\n");
-            break;
-        }
-        for (int i = 0; i < _brightnessCount; i++)
-        {
-            OSNumber* num = OSDynamicCast(OSNumber, array->getObject(i));
-            int brightness = num ? num->unsigned32BitValue() : 0;
-            _brightnessLevels[i] = brightness;
-        }
-#ifdef DEBUG_VERBOSE
-        DEBUG_LOG("ps2br: Brightness levels: { ");
-        for (int i = 0; i < _brightnessCount; i++)
-            DEBUG_LOG("%d, ", _brightnessLevels[i]);
-        DEBUG_LOG("}\n");
-#endif
-        break;
-    } while (false);
-    
-    OSSafeReleaseNULL(res);
-
     // get IOACPIPlatformDevice for Device (PS2K)
     //REVIEW: should really look at the parent chain for IOACPIPlatformDevice instead.
     _provider = (IOACPIPlatformDevice*)IORegistryEntry::fromPath("IOService:/AppleACPIPlatformExpert/PS2K");

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -372,32 +372,32 @@ IORegistryEntry* ApplePS2Keyboard::getDevicebyAddress(IORegistryEntry *parent, i
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 IORegistryEntry* ApplePS2Keyboard::getBrightnessPanel() {
-	IORegistryEntry *panel = nullptr;
+    IORegistryEntry *panel = nullptr;
 
-	auto info = DeviceInfo::create();
+    auto info = DeviceInfo::create();
 
-	auto getAcpiDevice = [](IORegistryEntry *dev) -> IORegistryEntry * {
-		if (dev == nullptr)
-			return nullptr;
+    auto getAcpiDevice = [](IORegistryEntry *dev) -> IORegistryEntry * {
+        if (dev == nullptr)
+            return nullptr;
 
-		auto path = OSDynamicCast(OSString, dev->getProperty("acpi-path"));
-		if (path != nullptr)
-			return IORegistryEntry::fromPath(path->getCStringNoCopy());
-		return nullptr;
-	};
+        auto path = OSDynamicCast(OSString, dev->getProperty("acpi-path"));
+        if (path != nullptr)
+            return IORegistryEntry::fromPath(path->getCStringNoCopy());
+        return nullptr;
+    };
 
-	if (info) {
-		if (info->videoBuiltin != nullptr)
-			panel = getAcpiDevice(getDevicebyAddress(info->videoBuiltin, 0x400));
+    if (info) {
+        if (info->videoBuiltin != nullptr)
+            panel = getAcpiDevice(getDevicebyAddress(info->videoBuiltin, 0x400));
 
-		if (panel == nullptr)
-			for (size_t i = 0; panel == nullptr && i < info->videoExternal.size(); ++i)
-				panel = getAcpiDevice(getDevicebyAddress(info->videoExternal[i].video, 0x110));
+        if (panel == nullptr)
+            for (size_t i = 0; panel == nullptr && i < info->videoExternal.size(); ++i)
+                panel = getAcpiDevice(getDevicebyAddress(info->videoExternal[i].video, 0x110));
 
-		DeviceInfo::deleter(info);
-	}
+        DeviceInfo::deleter(info);
+    }
 
-	return panel;
+    return panel;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -446,7 +446,7 @@ bool ApplePS2Keyboard::start(IOService * provider)
     }
     
     // get IOACPIPlatformDevice for built-in panel
-	_panel = OSDynamicCast(IOACPIPlatformDevice, getBrightnessPanel());
+    _panel = OSDynamicCast(IOACPIPlatformDevice, getBrightnessPanel());
     if (_panel != nullptr) {
         if ((_panelNotifiers = _panel->registerInterest(gIOGeneralInterest, _panelNotification, this)))
             setProperty(kBrightnessDevice, _panel->getName());

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -383,7 +383,7 @@ IOACPIPlatformDevice* ApplePS2Keyboard::getBrightnessPanel() {
         auto path = OSDynamicCast(OSString, dev->getProperty("acpi-path"));
         if (path != nullptr) {
             auto p = IORegistryEntry::fromPath(path->getCStringNoCopy());
-            auto r = (IOACPIPlatformDevice*)p;
+            auto r = OSDynamicCast(IOACPIPlatformDevice, p);
             if (r) return r;
             OSSafeRelease(p);
         }

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -355,9 +355,9 @@ IORegistryEntry* ApplePS2Keyboard::getDevicebyAddress(IORegistryEntry *parent, i
         IORegistryEntry* dev;
         int addr;
         while ((dev = (IORegistryEntry*)iter->getNextObject())) {
-			auto location = dev->getLocation();
-			// The device need to be present in ACPI scope and follow the naming convention ('A'-'Z', '_')
-			auto name = dev->getName();
+            auto location = dev->getLocation();
+            // The device need to be present in ACPI scope and follow the naming convention ('A'-'Z', '_')
+            auto name = dev->getName();
             if (location && name && name [0] <= '_' &&
                 sscanf(dev->getLocation(), "%x", &addr) == 1 && addr == address) {
                 child = dev;
@@ -383,7 +383,7 @@ IOACPIPlatformDevice* ApplePS2Keyboard::getBrightnessPanel() {
         auto path = OSDynamicCast(OSString, dev->getProperty("acpi-path"));
         if (path != nullptr) {
             auto p = IORegistryEntry::fromPath(path->getCStringNoCopy());
-            auto r = OSDynamicCast(IOACPIPlatformDevice, p);
+            auto r = (IOACPIPlatformDevice*)p;
             if (r) return r;
             OSSafeRelease(p);
         }

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -354,7 +354,11 @@ IORegistryEntry* ApplePS2Keyboard::getDevicebyAddress(IORegistryEntry *parent, i
         IORegistryEntry* dev;
         int addr;
         while ((dev = (IORegistryEntry *)iter->getNextObject())) {
-            if ((sscanf(dev->getLocation(), "%x", &addr) == 1) && addr == address) {
+            if ((dev->getLocation()) &&
+                // The device need to be present in ACPI scope and follow the naming convention
+                ((dev->getName())[0] <= '_') &&
+                (sscanf(dev->getLocation(), "%x", &addr) == 1) &&
+                addr == address) {
                 child = dev;
                 break;
             }
@@ -367,26 +371,21 @@ IORegistryEntry* ApplePS2Keyboard::getDevicebyAddress(IORegistryEntry *parent, i
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 IORegistryEntry* ApplePS2Keyboard::getDisplay() {
-    IORegistryEntry* entry = nullptr;
-    IORegistryEntry* display = nullptr;
+    IORegistryEntry* root;
+    IORegistryEntry* pci;
+    IORegistryEntry* gfx;
     IORegistryEntry* dev;
-    OSString* path = nullptr;
+    OSString* path;
 
-    // Waiting for IGPU
-    size_t counter = 20;
-    while (counter--) {
-        if ((entry = IORegistryEntry::fromPath("/PCI0/IGPU", gIODTPlane)))
-            break;
-        IOSleep(150);
+    if ((root = IORegistryEntry::fromPath("/", gIODTPlane)) &&
+        (pci = getDevicebyAddress(root, 0)) &&
+        (gfx = getDevicebyAddress(pci, 2)) &&
+        (dev = getDevicebyAddress(gfx, 0x400)) &&
+        (path = OSDynamicCast(OSString, dev->getProperty("acpi-path")))) {
+        root->release();
+        return IORegistryEntry::fromPath(path->getCStringNoCopy());
     }
-
-    if ((entry) &&
-        (dev = getDevicebyAddress(entry, 0x400)) &&
-        (path = OSDynamicCast(OSString, dev->getProperty("acpi-path"))))
-        display = IORegistryEntry::fromPath(path->getCStringNoCopy());
-    
-    OSSafeRelease(entry);
-    return display;
+    return nullptr;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -443,6 +442,56 @@ bool ApplePS2Keyboard::start(IOService * provider)
         else
             IOLog("ps2br: unable to register interest for GFX notifications\n");
     }
+
+    OSObject* res = 0;
+    if (_gfx) do
+    {
+        // check for brightness methods
+        if (kIOReturnSuccess != _gfx->validateObject("_BCL") || kIOReturnSuccess != _gfx->validateObject("_BCM") || kIOReturnSuccess != _gfx->validateObject("_BQC"))
+        {
+            break;
+        }
+        // methods are there, so now try to collect brightness levels
+        if (kIOReturnSuccess != _gfx->evaluateObject("_BCL", &res))
+        {
+            DEBUG_LOG("ps2br: _BCL returned error\n");
+            break;
+        }
+        OSArray* array = OSDynamicCast(OSArray, res);
+        if (!array)
+        {
+            DEBUG_LOG("ps2br: _BCL returned non-array package\n");
+            break;
+        }
+        int count = array->getCount();
+        if (count < 4)
+        {
+            DEBUG_LOG("ps2br: _BCL returned invalid package\n");
+            break;
+        }
+        _brightnessCount = count;
+        _brightnessLevels = new int[_brightnessCount];
+        if (!_brightnessLevels)
+        {
+            DEBUG_LOG("ps2br: _brightnessLevels new int[] failed\n");
+            break;
+        }
+        for (int i = 0; i < _brightnessCount; i++)
+        {
+            OSNumber* num = OSDynamicCast(OSNumber, array->getObject(i));
+            int brightness = num ? num->unsigned32BitValue() : 0;
+            _brightnessLevels[i] = brightness;
+        }
+#ifdef DEBUG_VERBOSE
+        DEBUG_LOG("ps2br: Brightness levels: { ");
+        for (int i = 0; i < _brightnessCount; i++)
+            DEBUG_LOG("%d, ", _brightnessLevels[i]);
+        DEBUG_LOG("}\n");
+#endif
+        break;
+    } while (false);
+    
+    OSSafeReleaseNULL(res);
 
     // get IOACPIPlatformDevice for Device (PS2K)
     //REVIEW: should really look at the parent chain for IOACPIPlatformDevice instead.

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -112,7 +112,6 @@ private:
     bool                        _panelNotified;
     bool                        _panelPrompt;
     IONotifier *                _panelNotifiers;
-    static IOReturn             _panelNotification(void *target, void *refCon, UInt32 messageType, IOService *provider, void *messageArgument, vm_size_t argSize);
 
     IOACPIPlatformDevice *      _provider;
     int *                       _brightnessLevels;
@@ -146,7 +145,8 @@ private:
     virtual void initKeyboard();
     virtual void setDevicePowerState(UInt32 whatToDo);
     IORegistryEntry* getDevicebyAddress(IORegistryEntry *parent, int address);
-    IORegistryEntry* getDisplay();
+    IORegistryEntry* getBuiltinPanel();
+    static IOReturn _panelNotification(void *target, void *refCon, UInt32 messageType, IOService *provider, void *messageArgument, vm_size_t argSize);
     void modifyKeyboardBacklight(int adbKeyCode, bool goingDown);
     void modifyScreenBrightness(int adbKeyCode, bool goingDown);
     inline bool checkModifierState(UInt16 mask)

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -145,7 +145,7 @@ private:
     virtual void initKeyboard();
     virtual void setDevicePowerState(UInt32 whatToDo);
     IORegistryEntry* getDevicebyAddress(IORegistryEntry *parent, int address);
-    IORegistryEntry* getBrightnessPanel();
+    IOACPIPlatformDevice* getBrightnessPanel();
     static IOReturn _panelNotification(void *target, void *refCon, UInt32 messageType, IOService *provider, void *messageArgument, vm_size_t argSize);
     void modifyKeyboardBacklight(int adbKeyCode, bool goingDown);
     void modifyScreenBrightness(int adbKeyCode, bool goingDown);

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -30,6 +30,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winconsistent-missing-override"
 #include <IOKit/acpi/IOACPIPlatformDevice.h>
+#include <IOKit/IODeviceTreeSupport.h>
 #pragma clang diagnostic pop
 
 #include <IOKit/IOCommandGate.h>
@@ -144,6 +145,7 @@ private:
     virtual void setKeyboardEnable(bool enable);
     virtual void initKeyboard();
     virtual void setDevicePowerState(UInt32 whatToDo);
+    bool findBrightnessDevice();
     void modifyKeyboardBacklight(int adbKeyCode, bool goingDown);
     void modifyScreenBrightness(int adbKeyCode, bool goingDown);
     inline bool checkModifierState(UInt16 mask)

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -145,7 +145,7 @@ private:
     virtual void setKeyboardEnable(bool enable);
     virtual void initKeyboard();
     virtual void setDevicePowerState(UInt32 whatToDo);
-    bool findBrightnessDevice();
+    IORegistryEntry* getDisplay();
     void modifyKeyboardBacklight(int adbKeyCode, bool goingDown);
     void modifyScreenBrightness(int adbKeyCode, bool goingDown);
     inline bool checkModifierState(UInt16 mask)

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -145,7 +145,7 @@ private:
     virtual void initKeyboard();
     virtual void setDevicePowerState(UInt32 whatToDo);
     IORegistryEntry* getDevicebyAddress(IORegistryEntry *parent, int address);
-    IORegistryEntry* getBuiltinPanel();
+    IORegistryEntry* getBrightnessPanel();
     static IOReturn _panelNotification(void *target, void *refCon, UInt32 messageType, IOService *provider, void *messageArgument, vm_size_t argSize);
     void modifyKeyboardBacklight(int adbKeyCode, bool goingDown);
     void modifyScreenBrightness(int adbKeyCode, bool goingDown);

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -107,12 +107,12 @@ private:
     IOTimerEventSource*         _sleepEjectTimer;
     UInt32                      _maxsleeppresstime;
 
-    // ACPI support for screen brightness
-    IOACPIPlatformDevice *      _gfx;
-    bool                        _gfxKey;
-    bool                        _gfxKeyPrompt;
-    IONotifier *                _gfxNotifiers;
-    static IOReturn             _gfxNotification(void *target, void *refCon, UInt32 messageType, IOService *provider, void *messageArgument, vm_size_t argSize);
+    // ACPI support for panel brightness
+    IOACPIPlatformDevice *      _panel;
+    bool                        _panelNotified;
+    bool                        _panelPrompt;
+    IONotifier *                _panelNotifiers;
+    static IOReturn             _panelNotification(void *target, void *refCon, UInt32 messageType, IOService *provider, void *messageArgument, vm_size_t argSize);
 
     IOACPIPlatformDevice *      _provider;
     int *                       _brightnessLevels;

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -107,6 +107,12 @@ private:
     UInt32                      _maxsleeppresstime;
 
     // ACPI support for screen brightness
+    IOACPIPlatformDevice *      _gfx;
+    bool                        _gfxKey;
+    bool                        _gfxKeyPrompt;
+    IONotifier *                _gfxNotifiers;
+    static IOReturn             _gfxNotification(void *target, void *refCon, UInt32 messageType, IOService *provider, void *messageArgument, vm_size_t argSize);
+
     IOACPIPlatformDevice *      _provider;
     int *                       _brightnessLevels;
     int                         _brightnessCount;

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -145,6 +145,7 @@ private:
     virtual void setKeyboardEnable(bool enable);
     virtual void initKeyboard();
     virtual void setDevicePowerState(UInt32 whatToDo);
+    IORegistryEntry* getDevicebyAddress(IORegistryEntry *parent, int address);
     IORegistryEntry* getDisplay();
     void modifyKeyboardBacklight(int adbKeyCode, bool goingDown);
     void modifyScreenBrightness(int adbKeyCode, bool goingDown);


### PR DESCRIPTION
EC query for brightness key usually notifies a device under IGPU(GFX0).
For example:
```
Method (_Q14, 0, NotSerialized)
{
    Notify (\_SB.PCI0.GFX0.DD1F, 0x86)
}

Method (_Q15, 0, NotSerialized)
{
    Notify (\_SB.PCI0.GFX0.DD1F, 0x87)
}
```
The device usually has an `_ADR` of 0x400 and is named as `DD1F` on Haswell+ machines (`DD02` for Sandy Bridge). By subscribing to ACPI notification of this device, brightness key will work out of box.

According to ACPI Spec Appendix B.6, `0x86` is for Increase Brightness and `0x87` is for Decrease Brightness. It also defines `0x85` for Cycle Brightness, `0x88` for Zero Brightness and `0x89` for Display Device Off. However latter ones don't have corresponding ADB key and are rarely used or handled by firmware.

For machines with patched DSDT, possible duplicated input will be ignored for compatibility.

There's also `_BCL`, `_BCM`, `_BQC` method to adjust panel brightness. Are them deprecated now in favor of SSDT-PNLF? Rehabman introduced `KBCL`, `KBCM`, `KBQC` under PS2K to call these methods. But this part haven't been updated for a long time.