### PR TITLE
Workaround for ICL/CML brightness keys

### DIFF
--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -172,6 +172,8 @@
 #define kIOACPILCDDisplay               0x0400  // For integrated graphics
 #define kIOACPILegacyPanel              0x0110  // For discrete graphics
 
+#define kIOACPIDefaultLCDDisplay        0x1f    // Default _ADR for not configured LCD display, mostly on ICL / CML 
+
 // name of drivers/services as registered
 
 #define kApplePS2Controller          "ApplePS2Controller"

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -169,10 +169,11 @@
 #define kIOACPIMessageBrightnessZero    0x88    // Zero Brightness
 #define kIOACPIMessageBrightnessOff     0x89    // Display Device Off
  
+#define kIOACPICRTMonitor               0x0100  // For integrated graphics
 #define kIOACPILCDDisplay               0x0400  // For integrated graphics
 #define kIOACPILegacyPanel              0x0110  // For discrete graphics
 
-#define kIOACPIDefaultLCDDisplay        0x1f    // Default _ADR for not configured LCD display, mostly on ICL / CML 
+#define kIOACPIDefaultLCDDisplay        0x1f    // Default _ADR for not configured LCD display, mostly on ICL / CML
 
 // name of drivers/services as registered
 

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -173,8 +173,6 @@
 #define kIOACPILCDDisplay               0x0400  // For integrated graphics
 #define kIOACPILegacyPanel              0x0110  // For discrete graphics
 
-#define kIOACPIDefaultLCDDisplay        0x1f    // Default _ADR for not configured LCD display, mostly on ICL / CML
-
 // name of drivers/services as registered
 
 #define kApplePS2Controller          "ApplePS2Controller"

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -160,7 +160,7 @@
 #define kSC_NumLock             0x45
 
 //
-// ACPI message for brightness keys.
+// ACPI message and device type for brightness keys.
 //
 
 #define kIOACPIMessageBrightnessCycle   0x85    // Cycle Brightness
@@ -168,6 +168,9 @@
 #define kIOACPIMessageBrightnessDown    0x87    // Decrease Brightness
 #define kIOACPIMessageBrightnessZero    0x88    // Zero Brightness
 #define kIOACPIMessageBrightnessOff     0x89    // Display Device Off
+ 
+#define kIOACPILCDDisplay               0x0400  // For integrated graphics
+#define kIOACPILegacyPanel              0x0110  // For discrete graphics
 
 // name of drivers/services as registered
 

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -392,20 +392,20 @@ IOACPIPlatformDevice* ApplePS2Keyboard::getBrightnessPanel() {
 
     if (info) {
         if (info->videoBuiltin != nullptr) {
-            panel = getAcpiDevice(getDevicebyAddress(info->videoBuiltin, 0x400));
+            panel = getAcpiDevice(getDevicebyAddress(info->videoBuiltin, kIOACPILCDDisplay));
 
             //
-            // On some IceLake Laptops, address of display output device may not export panel
-            // information, use 1f for DD1F instead
+            // On some Ice Lake and Comet Lake Laptops, address of display output device
+            // may not export panel information, use 1f for DD1F instead
             //
             if (panel == nullptr)
-                if (BaseDeviceInfo::get().cpuGeneration == CPUInfo::CpuGeneration::IceLake)
+                if (BaseDeviceInfo::get().cpuGeneration >= CPUInfo::CpuGeneration::IceLake)
                     panel = getAcpiDevice(getDevicebyAddress(info->videoBuiltin, 0x1f));
         }
 
         if (panel == nullptr)
             for (size_t i = 0; panel == nullptr && i < info->videoExternal.size(); ++i)
-                panel = getAcpiDevice(getDevicebyAddress(info->videoExternal[i].video, 0x110));
+                panel = getAcpiDevice(getDevicebyAddress(info->videoExternal[i].video, kIOACPILegacyPanel));
 
         DeviceInfo::deleter(info);
     }

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -391,8 +391,17 @@ IOACPIPlatformDevice* ApplePS2Keyboard::getBrightnessPanel() {
     };
 
     if (info) {
-        if (info->videoBuiltin != nullptr)
+        if (info->videoBuiltin != nullptr) {
             panel = getAcpiDevice(getDevicebyAddress(info->videoBuiltin, 0x400));
+
+            //
+            // On some IceLake Laptops, address of display output device may not export panel
+            // information, use 1f for DD1F instead
+            //
+            if (panel == nullptr)
+                if (BaseDeviceInfo::get().cpuGeneration == CPUInfo::CpuGeneration::IceLake)
+                    panel = getAcpiDevice(getDevicebyAddress(info->videoBuiltin, 0x1f));
+        }
 
         if (panel == nullptr)
             for (size_t i = 0; panel == nullptr && i < info->videoExternal.size(); ++i)

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -400,9 +400,14 @@ IOACPIPlatformDevice* ApplePS2Keyboard::getBrightnessPanel() {
             // a DOD of CRT type present, which should present when types are
             // initialized correctly. If not, use DD1F instead.
             //
-            if (panel == nullptr)
-                if (!getDevicebyAddress(info->videoBuiltin, kIOACPICRTMonitor))
-                    panel = getAcpiDevice(info->videoBuiltin->childFromPath("DD1F"));
+            if (panel == nullptr) {
+                IORegistryEntry *defaultLCD;
+                if (!getDevicebyAddress(info->videoBuiltin, kIOACPICRTMonitor) &&
+                    (defaultLCD = info->videoBuiltin->childFromPath("DD1F"))) {
+                    panel = getAcpiDevice(defaultLCD);
+                    defaultLCD->release();
+                }
+            }
         }
 
         if (panel == nullptr)

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -395,12 +395,12 @@ IOACPIPlatformDevice* ApplePS2Keyboard::getBrightnessPanel() {
             panel = getAcpiDevice(getDevicebyAddress(info->videoBuiltin, kIOACPILCDDisplay));
 
             //
-            // On some Ice Lake and Comet Lake Laptops, address of display output device
+            // On some Ice Lake and Comet Lake laptops, address of Display Output Device (DOD)
             // may not export panel information, use 1f for DD1F instead
             //
             if (panel == nullptr)
                 if (BaseDeviceInfo::get().cpuGeneration >= CPUInfo::CpuGeneration::IceLake)
-                    panel = getAcpiDevice(getDevicebyAddress(info->videoBuiltin, 0x1f));
+                    panel = getAcpiDevice(getDevicebyAddress(info->videoBuiltin, kIOACPIDefaultLCDDisplay));
         }
 
         if (panel == nullptr)

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -398,12 +398,11 @@ IOACPIPlatformDevice* ApplePS2Keyboard::getBrightnessPanel() {
             // On some newer laptops, address of Display Output Device (DOD)
             // may not export panel information. We can verify it by whether
             // a DOD of CRT type present, which should present when types are
-            // initialized correctly. If not, use 1f for DD1F instead.
+            // initialized correctly. If not, use DD1F instead.
             //
-            if (panel == nullptr) {
+            if (panel == nullptr)
                 if (!getDevicebyAddress(info->videoBuiltin, kIOACPICRTMonitor))
-                    panel = getAcpiDevice(getDevicebyAddress(info->videoBuiltin, kIOACPIDefaultLCDDisplay));
-            }
+                    panel = getAcpiDevice(info->videoBuiltin->childFromPath("DD1F"));
         }
 
         if (panel == nullptr)

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -395,12 +395,15 @@ IOACPIPlatformDevice* ApplePS2Keyboard::getBrightnessPanel() {
             panel = getAcpiDevice(getDevicebyAddress(info->videoBuiltin, kIOACPILCDDisplay));
 
             //
-            // On some Ice Lake and Comet Lake laptops, address of Display Output Device (DOD)
-            // may not export panel information, use 1f for DD1F instead
+            // On some newer laptops, address of Display Output Device (DOD)
+            // may not export panel information. We can verify it by whether
+            // a DOD of CRT type present, which should present when types are
+            // initialized correctly. If not, use 1f for DD1F instead.
             //
-            if (panel == nullptr)
-                if (BaseDeviceInfo::get().cpuGeneration >= CPUInfo::CpuGeneration::IceLake)
+            if (panel == nullptr) {
+                if (!getDevicebyAddress(info->videoBuiltin, kIOACPICRTMonitor))
                     panel = getAcpiDevice(getDevicebyAddress(info->videoBuiltin, kIOACPIDefaultLCDDisplay));
+            }
         }
 
         if (panel == nullptr)

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -403,7 +403,7 @@ IOACPIPlatformDevice* ApplePS2Keyboard::getBrightnessPanel() {
             if (panel == nullptr) {
                 IORegistryEntry *defaultLCD;
                 if (!getDevicebyAddress(info->videoBuiltin, kIOACPICRTMonitor) &&
-                    (defaultLCD = info->videoBuiltin->childFromPath("DD1F"))) {
+                    (defaultLCD = info->videoBuiltin->childFromPath("DD1F", gIODTPlane))) {
                     panel = getAcpiDevice(defaultLCD);
                     defaultLCD->release();
                 }


### PR DESCRIPTION
On some Ice Lake and Comet Lake Laptops, address of display output device may not export panel information, use `0x1f` for `DD1F` instead.

Constant name borrowed from https://github.com/torvalds/linux/blob/master/include/acpi/video.h