### PR TITLE
Workaround for buggy vendor backlight implements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ VoodooPS2 Changelog
 - Improved native brightness keys discovery on CML/ICL
 
 #### v2.1.7
-- Added ability for native brightness keys discovery with `Lilu` API, please be aware of this new dependecy and drop SSDT modification to corresponding `_QXX`.
+- Added ability for native brightness keys discovery with `Lilu` API, please be aware of this new dependency and drop SSDT modification to corresponding `_QXX`.
 - Added constants for 11.0 support
 
 #### v2.1.6

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -161,6 +161,7 @@
 
 //
 // ACPI message and device type for brightness keys.
+// See ACPI Specification, Appendix B: Video Extensions for details
 //
 
 #define kIOACPIMessageBrightnessCycle   0x85    // Cycle Brightness
@@ -169,9 +170,12 @@
 #define kIOACPIMessageBrightnessZero    0x88    // Zero Brightness
 #define kIOACPIMessageBrightnessOff     0x89    // Display Device Off
  
-#define kIOACPICRTMonitor               0x0100  // For integrated graphics
-#define kIOACPILCDDisplay               0x0400  // For integrated graphics
-#define kIOACPILegacyPanel              0x0110  // For discrete graphics
+#define kIOACPIDisplayTypeMask          0x0F00
+
+#define kIOACPICRTMonitor               0x0100  // VGA* CRT or VESA* Compatible Analog Monitor
+#define kIOACPILCDPanel                 0x0400  // Internal/Integrated Digital Flat Panel
+
+#define kIOACPILegacyPanel              0x0110  // Integrated LCD Panel #1 using a common, backwards compatible ID
 
 // name of drivers/services as registered
 

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -1074,9 +1074,16 @@ void ApplePS2Keyboard::stop(IOService * provider)
     //
     if (_panel && _panelNotifiers)
         _panelNotifiers->remove();
-    if (_panelFallback && _panelNotifiers)
-        _panelNotifiers->remove();
+
+    if (_panelFallback && _panelNotifiersFallback)
+        _panelNotifiersFallback->remove();
+
+    if (_panelDiscrete && _panelNotifiersDiscrete)
+        _panelNotifiersDiscrete->remove();
+
     OSSafeReleaseNULL(_panel);
+    OSSafeReleaseNULL(_panelFallback);
+    OSSafeReleaseNULL(_panelDiscrete);
     OSSafeReleaseNULL(_provider);
     
     //

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -106,9 +106,13 @@ private:
 
     // ACPI support for panel brightness
     IOACPIPlatformDevice *      _panel;
+    IOACPIPlatformDevice *      _panelFallback;
+    IOACPIPlatformDevice *      _panelDiscrete;
     bool                        _panelNotified;
     bool                        _panelPrompt;
     IONotifier *                _panelNotifiers;
+    IONotifier *                _panelNotifiersFallback;
+    IONotifier *                _panelNotifiersDiscrete;
 
     IOACPIPlatformDevice *      _provider;
     int *                       _brightnessLevels;
@@ -141,8 +145,8 @@ private:
     virtual void setKeyboardEnable(bool enable);
     virtual void initKeyboard();
     virtual void setDevicePowerState(UInt32 whatToDo);
-    IORegistryEntry* getDevicebyAddress(IORegistryEntry *parent, int address);
-    IOACPIPlatformDevice* getBrightnessPanel();
+    IORegistryEntry* getDevicebyAddress(IORegistryEntry *parent, int address, int mask = 0xFFFFFFFF);
+    void getBrightnessPanel();
     static IOReturn _panelNotification(void *target, void *refCon, UInt32 messageType, IOService *provider, void *messageArgument, vm_size_t argSize);
     void modifyKeyboardBacklight(int adbKeyCode, bool goingDown);
     void modifyScreenBrightness(int adbKeyCode, bool goingDown);


### PR DESCRIPTION
Yesterday I was notified for another exception.

The [structure](https://user-content.gitter-static.net/beb023f1e5b5c86ed29bd1bd6c297f43dfc3631d/68747470733a2f2f66696c65732e6769747465722e696d2f3566313637663163643733343038636534666561313934362f567258632f7468756d622f696d6167652e706e67) is:

```
GFX0@20000
- DD01@100
- DD02@2
- DD03@300
- DD04@301
- DD05@5
- DD06@6
- DD07@7
- DD08@8
- DD09@9
- DD0A@a
- DD0B@b
- DD0C@c
- DD0D@d
- DD0E@e
- DD0F@f
- DD1F@410
```

Which is quite similar to my desktop one
```
GFX0@20000
- DD01@100
- DD02@2
- DD03@300
- DD04@301
- DD05@302
- DD06@6
- DD07@7
- DD08@8
- DD09@9
- DD0A@a
- DD0B@b
- DD0C@c
- DD0D@d
- DD0E@e
- DD0F@f
- DD1F@1f
```

I added a mask to verify bit [11:8] for display type. However, later I was told `DD02` was actually notified.
```
        Method (_Q1C, 0, NotSerialized)  // _Qxx: EC Query, xx=0x00-0xFF
        {
            P80H = 0x1C
            BCEN = Zero
            BCVE = Zero
            If (QWIK) // non-zero
            {
                Notify (^^^GFX0.DD02, 0x86) // Device-Specific
            }
            ElseIf (BCEN)
            {
                If (BCVE)
                {
                    If ((^^^GFX0.IGID != 0xFFFF))
                    {
                        ^^^GFX0.SPBR (BNVA, Zero)
                    }
                }

                LAMN (0x73)
            }
            Else
            {
                Acquire (MSGF, 0xFFFF)
                If ((^^^GFX0.IGID != 0xFFFF))
                {
                    BIAN (0x86) // will notify DD1F correctly
                }

                Release (MSGF)
            }
        }
```

The result didn't follow the spec as well. I suppose it's a mis-configuration that route to obsolete `DD02` again.

 I didn't come up with some good idea to identify that. So maybe it could be handled by additional fallback notifier?