### PR TITLE
Remove obsolete ACPI brightness control

### DIFF
--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -173,7 +173,7 @@ bool ApplePS2Keyboard::init(OSDictionary * dict)
     _keysSpecial = 0;
     _f12ejectdelay = 250;   // default is 250 ms
 
-    // initialize ACPI support for keyboard backlight/screen brightness
+    // initialize ACPI support for keyboard backlight
     _provider = 0;
     _backlightLevels = 0;
     
@@ -896,6 +896,15 @@ void ApplePS2Keyboard::stop(IOService * provider)
     // Release ACPI provider for PS2K ACPI device
     //
     OSSafeReleaseNULL(_provider);
+
+    //
+    // Release data related to keyboard backlight
+    //
+    if (_backlightLevels)
+    {
+        delete[] _backlightLevels;
+        _backlightLevels = 0;
+    }
 
     OSSafeReleaseNULL(_keysStandard);
     OSSafeReleaseNULL(_keysSpecial);

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -103,12 +103,8 @@ private:
     IOTimerEventSource*         _sleepEjectTimer;
     UInt32                      _maxsleeppresstime;
 
-    // ACPI support for screen brightness
-    IOACPIPlatformDevice *      _provider;
-    int *                       _brightnessLevels;
-    int                         _brightnessCount;
-
     // ACPI support for keyboard backlight
+    IOACPIPlatformDevice *      _provider;
     int *                       _backlightLevels;
     int                         _backlightCount;
     


### PR DESCRIPTION
This legacy support for brightness utilizes proxy methods `KBCL`, `KBCM`, `KBQC` to `_BCL`, `_BCM`, `_BQC` under corresponding display output device according to https://www.tonymacx86.com/threads/new-voodoops2controller-keyboard-trackpad.75649/post-560175 .

However, it has been replaced with `SSDT-PNLF`. Also, this approach won't create an OSD notification. If it's necessary to implemented legacy support as a fallback, call those methods natively in BrightnessKeys is better.