### PR TITLE
Improve key time dispatch

### DIFF
--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -2012,7 +2012,7 @@ void ApplePS2Controller::dispatchMessageGated(int* message, void* data)
         
         switch (pInfo->adbKeyCode)
         {
-                // Do not trigger on modifier key presses (for example multi-click select)
+            // Do not trigger on modifier key presses (for example multi-click select)
             case 0x38:  // left shift
             case 0x3c:  // right shift
             case 0x3b:  // left control

--- a/VoodooPS2Mouse/VoodooPS2Mouse.cpp
+++ b/VoodooPS2Mouse/VoodooPS2Mouse.cpp
@@ -1263,27 +1263,11 @@ IOReturn ApplePS2Mouse::message(UInt32 type, IOService* provider, void* argument
             break;
         }
             
-        case kPS2M_notifyKeyPressed:
+        case kPS2M_notifyKeyTime:
         {
             // just remember last time key pressed... this can be used in
             // interrupt handler to detect unintended input while typing
-            PS2KeyInfo* pInfo = (PS2KeyInfo*)argument;
-            switch (pInfo->adbKeyCode)
-            {
-                    // don't store key time for modifier keys going down
-                case 0x38:  // left shift
-                case 0x3c:  // right shift
-                case 0x3b:  // left control
-                case 0x3e:  // right control
-                case 0x3a:  // left alt (command)
-                case 0x3d:  // right alt
-                case 0x37:  // left windows (option)
-                case 0x36:  // right windows
-                    if (pInfo->goingDown)
-                        break;
-                default:
-                    keytime = pInfo->time;
-            }
+            keytime = *((uint64_t*)argument);
             break;
         }
     }

--- a/VoodooPS2Trackpad/VoodooPS2Elan.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2Elan.cpp
@@ -470,12 +470,11 @@ IOReturn ApplePS2Elan::message(UInt32 type, IOService* provider, void* argument)
             break;
         }
 
-        case kPS2M_notifyKeyPressed:
+        case kPS2M_notifyKeyTime:
         {
             // just remember last time key pressed... this can be used in
             // interrupt handler to detect unintended input while typing
-            PS2KeyInfo* pInfo = (PS2KeyInfo*)argument;
-            keytime = pInfo->time;
+            keytime = *((uint64_t*)argument);
             break;
         }
     }


### PR DESCRIPTION
This pull request replaces `kPS2M_notifyKeyPressed` with `kPS2M_notifyKeyTime` in `VoodooPS2Mouse` and `VoodooPS2Elan`.

`kPS2M_notifyKeyTime` already ignores modifier keys so we don't need to do it again in `VoodooPS2Mouse`.  I forgot to ignore modifier keys in `VoodooPS2Elan` before (my bad). This also fix that.

I don't change `VoodooPS2Synaptics` because it needs keycode to determine waiting time.