### PR TITLE
Fix timestamp type for PS2KeyInfo; receiving PS2KeyInfo from other kext

### DIFF
--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -532,6 +532,9 @@ enum
     // from sensor (such as yoga mode indicator) to keyboard
     kPS2K_setKeyboardStatus = iokit_vendor_specific_msg(200),   // set disable/enable keyboard (data is bool*)
     kPS2K_getKeyboardStatus = iokit_vendor_specific_msg(201),   // get disable/enable keyboard (data is bool*)
+
+    // from OEM ACPI (WMI) events to keyboard
+    kPS2K_notifyKeystroke = iokit_vendor_specific_msg(210),     // notify of key press (data is PS2KeyInfo*)
 };
 
 typedef struct PS2KeyInfo

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -534,7 +534,7 @@ enum
     kPS2K_getKeyboardStatus = iokit_vendor_specific_msg(201),   // get disable/enable keyboard (data is bool*)
 
     // from OEM ACPI (WMI) events to keyboard
-    kPS2K_notifyKeystroke = iokit_vendor_specific_msg(210),     // notify of key press (data is PS2KeyInfo*)
+    kPS2K_notifyKeystroke = iokit_vendor_specific_msg(202),     // notify of key press (data is PS2KeyInfo*), in the opposite direction of kPS2M_notifyKeyPressed
 };
 
 typedef struct PS2KeyInfo

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -536,7 +536,7 @@ enum
 
 typedef struct PS2KeyInfo
 {
-    int64_t time;
+    uint64_t time;
     UInt16  adbKeyCode;
     bool    goingDown;
     bool    eatKey;

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -1004,6 +1004,19 @@ IOReturn ApplePS2Keyboard::message(UInt32 type, IOService* provider, void* argum
             }
             break;
         }
+
+        case kPS2K_notifyKeystroke:
+        {
+            if (argument) {
+                PS2KeyInfo *keystroke = (PS2KeyInfo*)argument;
+                if (!keystroke->eatKey) {
+                    // the key is consumed
+                    keystroke->eatKey = true;
+                    dispatchKeyboardEventX(keystroke->adbKeyCode, keystroke->goingDown, keystroke->time);
+                }
+            }
+            break;
+        }
     }
     return kIOReturnSuccess;
 }


### PR DESCRIPTION
Fortunately, none known kext use `kPS2M_notifyKeyPressed` or `iokit_vendor_specific_msg(102)`. And for another message `kPS2M_notifyKeyTime` or `iokit_vendor_specific_msg(110)`, it was marked as `uint64_t*` although pointed to the `int64_t time` in `PS2KeyInfo`.

The additional message is for other kexts like https://github.com/acidanthera/bugtracker/issues/1202.
