### PR TITLE
Add message to stop reset/power management for SMBus

### DIFF
--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -530,7 +530,7 @@ enum
     kPS2M_resetTouchpad = iokit_vendor_specific_msg(151),        // Force touchpad reset (data is int*)
     
     // from trackpad on I2C/SMBus
-    kPS2M_SMBusStart = iokit_vendor_specific_msg(152),          // Reset, disable PS2 comms to not interfere with SMBus comms, and return capabilities
+    kPS2M_SMBusStart = iokit_vendor_specific_msg(152),          // Reset, disable PS2 comms to not interfere with SMBus comms
     
     // from sensor (such as yoga mode indicator) to keyboard
     kPS2K_setKeyboardStatus = iokit_vendor_specific_msg(200),   // set disable/enable keyboard (data is bool*)

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -528,7 +528,10 @@ enum
     kPS2M_notifyKeyTime = iokit_vendor_specific_msg(110),        // notify of timestamp a non-modifier key was pressed (data is uint64_t*)
 
     kPS2M_resetTouchpad = iokit_vendor_specific_msg(151),        // Force touchpad reset (data is int*)
-
+    
+    // from trackpad on I2C/SMBus
+    kPS2M_SMBusStart = iokit_vendor_specific_msg(152),          // Reset, disable PS2 comms to not interfere with SMBus comms, and return capabilities
+    
     // from sensor (such as yoga mode indicator) to keyboard
     kPS2K_setKeyboardStatus = iokit_vendor_specific_msg(200),   // set disable/enable keyboard (data is bool*)
     kPS2K_getKeyboardStatus = iokit_vendor_specific_msg(201),   // get disable/enable keyboard (data is bool*)

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -2504,15 +2504,12 @@ IOReturn ApplePS2SynapticsTouchPad::message(UInt32 type, IOService* provider, vo
         case kPS2M_SMBusStart: {
             // Trackpad is being taken over by another driver
             
-            // Any standing up/querying done before this message can make the trackpad refuse to respond over SMBus.
-            // Resetting also fixes issues with HP laptops and other devices where having CSM or FastBoot enabled
-            //  breaks using SMBus
+            // Queries/standing up before this point needs to be reset
+            // Fixes issues with CSM/Fast Boot on HP laptops
             doHardwareReset();
             
             // Prevent any PS2 transactions, otherwise the trackpad can completely lock up from PS2 commands
-            // Generally it can be assumed that any querying/standing up is done before this point as that is all done before
-            //  registerService() (and waitForMatchingService()) is called. Therefore we only need to prevent
-            //  reset messages and power management.
+            // This is called after ::start (specifically registerService()), so only prevent power management/reset msgs
             otherBusInUse = true;
         }
     }

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -469,8 +469,6 @@ void ApplePS2SynapticsTouchPad::queryCapabilities()
     
     OSSafeReleaseNULL(dictionary);
     
-    registerService();
-
     INFO_LOG("VoodooPS2Trackpad: logical %dx%d-%dx%d physical_max %dx%d upmm %dx%d",
           logical_min_x, logical_min_y,
           logical_max_x, logical_max_y,
@@ -633,7 +631,7 @@ bool ApplePS2SynapticsTouchPad::start( IOService * provider )
     // Update LED -- it could have been disabled then computer was restarted
     //
     updateTouchpadLED();
-    
+    registerService();
     return true;
 }
 

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -345,6 +345,7 @@ void ApplePS2SynapticsTouchPad::queryCapabilities()
             }
         }
     }
+#ifdef DEBUG_MSG
     if (getTouchPadData(0x2, buf3))
     {
         INFO_LOG("VoodooPS2Trackpad: Capabilities($02) bytes = { 0x%x, 0x%x, 0x%x }\n", buf3[0], buf3[1], buf3[2]);
@@ -369,7 +370,7 @@ void ApplePS2SynapticsTouchPad::queryCapabilities()
     {
         INFO_LOG("VoodooPS2Trackpad: Extended Model($09) bytes = { 0x%x, 0x%x, 0x%x }\n", buf3[0], buf3[1], buf3[2]);
     }
-    
+#endif
     bool reportsMax = false;
     bool reportsMin = false;
     bool deluxeLeds = false;

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -334,7 +334,7 @@ void ApplePS2SynapticsTouchPad::queryCapabilities()
     if (getTouchPadData(0x1, buf3))
     {
         INFO_LOG("VoodooPS2Trackpad: Mode/model($01) bytes = { 0x%x, 0x%x, 0x%x }\n", buf3[0], buf3[1], buf3[2]);
-        // Only firmwares greater than 7.5 have board_id encoded
+        
         if (_touchPadVersion >= 0x705) {
             _boardID = ((buf3[0] & 0xfc) << 6) | buf3[1];
             setProperty("Board ID", _boardID, 32);
@@ -461,8 +461,7 @@ void ApplePS2SynapticsTouchPad::queryCapabilities()
     setProperty(VOODOO_INPUT_TRANSFORM_KEY, 0ull, 32);
     setProperty("VoodooInputSupported", kOSBooleanTrue);
 
-    // Publish capabilities to help find trackstick and clickpad buttons
-    // Helpful for SMBus drivers
+    // Helpful information for SMBus drivers
     OSDictionary *dictionary = OSDictionary::withCapacity(2);
     dictionary->setObject("TrackstickButtons", trackstickButtons ? kOSBooleanTrue : kOSBooleanFalse);
     dictionary->setObject("Clickpad", (clickpadtype & 0x1) ? kOSBooleanTrue : kOSBooleanFalse);

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
@@ -216,6 +216,7 @@ private:
 	UInt32              _packetByteCount {0};
     UInt8               _lastdata {0};
     UInt16              _touchPadVersion {0};
+    UInt32              _boardID {0};
     UInt8               _touchPadType {0}; // from identify: either 0x46 or 0x47
     UInt8               _touchPadModeByte {0x80}; //default: absolute, low-rate, no w-mode
     
@@ -300,12 +301,16 @@ private:
     bool tracksecondary {false};
     bool _extendedwmode {false}, _extendedwmodeSupported {false};
 
+    // Capabilities for SMBus
+    bool trackstickButtons {false};
+    
     // normal state
 	UInt32 passbuttons {0};
     UInt32 lastbuttons {0};
     uint64_t keytime {0};
     UInt16 keycode {0};
     bool ignoreall {false};
+    bool otherBusInUse {false}; // Trackpad being used over SMBus/I2C
 #ifdef SIMULATE_PASSTHRU
 	UInt32 trackbuttons {0};
 #endif


### PR DESCRIPTION
HP laptops commonly have CSM enabled to fix garbled graphics, though this leaves the trackpad in a bad state which prevent the trackpad from working over SMBus. The only way to fix this is to reset it over PS2 (no reset exists over SMBus). Additionally, this allows us to grab some capability information from the driver that is only really available over PS2. If there are issues injecting/adding SMBus drivers as well such as VoodooRMI, it still allows the trackpad to work over PS2 as a fail safe.

The way that the message is meant to be used is that the SMBus driver waits for VoodooPS2Trackpad to finish initializing, before sending the message to reset the trackpad. The PS2 driver needs to make sure though that once the other driver starts that it doesn't reset or send any PS2 commands. PS2 commands can cause the trackpad to lock up or go in some weird states when working under SMBus.