### PR TITLE
Num Lock Support

### DIFF
--- a/Docs/ACPI/SSDT-NumLockOnAtBoot.dsl
+++ b/Docs/ACPI/SSDT-NumLockOnAtBoot.dsl
@@ -1,0 +1,15 @@
+// Set NumLock state to ON at Bootup
+
+DefinitionBlock ("", "SSDT", 2, "ACDT", "ps2", 0)
+{
+    External (_SB_.PCI0.LPCB.PS2K, DeviceObj)
+    
+    Name(_SB.PCI0.LPCB.PS2K.RMCF, Package()
+    {
+        "Keyboard", Package()
+        {
+            "NumLockOnAtBoot", ">y",
+        },
+    })
+}
+//EOF

--- a/Docs/ACPI/SSDT-NumLockSupport.dsl
+++ b/Docs/ACPI/SSDT-NumLockSupport.dsl
@@ -1,0 +1,18 @@
+// Add Support for Num Lock key
+// By Default Voodoo maps Num Lock to Clear key because of the following
+// 1) On USB keyboards Num Lock is translated to the Clear key
+// 2) On Apple keyboards there is no Num Lock key
+
+DefinitionBlock ("", "SSDT", 2, "ACDT", "ps2", 0)
+{
+    External (_SB_.PCI0.LPCB.PS2K, DeviceObj)
+    
+    Name(_SB.PCI0.LPCB.PS2K.RMCF, Package()
+    {
+        "Keyboard", Package()
+        {
+            "NumLockSupport", ">y",
+        },
+    })
+}
+//EOF

--- a/VoodooPS2Controller.xcodeproj/project.pbxproj
+++ b/VoodooPS2Controller.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		356B896023007F4F0042F30F /* VoodooInputTransducer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VoodooInputTransducer.h; path = VoodooInput/Debug/VoodooInput.kext/Contents/Resources/VoodooInputMultitouch/VoodooInputTransducer.h; sourceTree = SOURCE_ROOT; };
 		356B896123007F4F0042F30F /* MultitouchHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MultitouchHelpers.h; path = VoodooInput/Debug/VoodooInput.kext/Contents/Resources/VoodooInputMultitouch/MultitouchHelpers.h; sourceTree = SOURCE_ROOT; };
 		4CC27EB2251FBC7700824FE1 /* VoodooPS2TrackpadCommon.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VoodooPS2TrackpadCommon.h; sourceTree = "<group>"; };
+		73119AB725E1961D0017311C /* SSDT-NumLockOnAtBoot.dsl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "SSDT-NumLockOnAtBoot.dsl"; sourceTree = "<group>"; };
+		73119AB825E1961D0017311C /* SSDT-NumLockSupport.dsl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "SSDT-NumLockSupport.dsl"; sourceTree = "<group>"; };
 		7B44762421D52A7100418B25 /* ApplePS2MouseDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ApplePS2MouseDevice.h; sourceTree = "<group>"; };
 		8404565C161E3AAF00D74D7F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		8404565F161E3AC300D74D7F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -313,6 +315,8 @@
 		CE7F450E22E8A842003F7971 /* ACPI */ = {
 			isa = PBXGroup;
 			children = (
+				73119AB725E1961D0017311C /* SSDT-NumLockOnAtBoot.dsl */,
+				73119AB825E1961D0017311C /* SSDT-NumLockSupport.dsl */,
 				CE7F451122E8A8C4003F7971 /* SSDT-MouseAsTrackpad.dsl */,
 				ED48777A207D94BC00D6B1E8 /* SSDT-AlternateSwipes.dsl */,
 				CEAFF570259F8AE700693DEC /* SSDT-DisableElanWakeDelay.dsl */,

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -99,6 +99,8 @@ private:
     UInt32                      _f12ejectdelay;
     enum { kTimerSleep, kTimerEject } _timerFunc;
     bool                        _remapPrntScr;
+    bool                        _numLockSupport;
+    bool                        _numLockOnAtBoot;
     
     // dealing with sleep key delay
     IOTimerEventSource*         _sleepEjectTimer;


### PR DESCRIPTION
- Num Lock Support
Map Num Lock (ScanCode 0x45) to Num Lock key, instead of Clear Key (default). Without this Numpad/Keypad on some laptops does not work. Because Num Lock state is set to Off at boot up (BIOS Setting have no effect).
- Num Lock ON at Boot
Set Num Lock State to On at boot up.

Fixes [#303](https://github.com/acidanthera/bugtracker/issues/303)