### PR TITLE
Run power action for all muxed mouse devices

### DIFF
--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -486,7 +486,7 @@ bool ApplePS2Controller::setMuxMode(bool enable)
     // Only log first time
     if (!_muxPresent)
     {
-      IOLog("ApplePS2Controller::hasMux = true - version: %x\n", ver);
+      IOLog("ApplePS2Controller::setMuxMode = true - version: %x\n" , ver);
     }
 
     return true;
@@ -1846,11 +1846,6 @@ void ApplePS2Controller::setPowerStateGated( UInt32 powerState )
         DEBUG_LOG("%s: setCommandByte for sleep 2\n", getName());
         setCommandByte(kCB_DisableKeyboardClock | kCB_DisableMouseClock, 0);
 #endif // DISABLE_CLOCKS_IRQS_BEFORE_SLEEP
-
-        // 5. Leave multiplexed mode.
-//        if (_muxPresent && !setMuxMode(false))
-//            IOLog("%s: Not able to leave mux mode for sleep\n", getName());
-
         break;
 
       case kPS2PowerStateDoze:

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -486,7 +486,7 @@ bool ApplePS2Controller::setMuxMode(bool enable)
     // Only log first time
     if (!_muxPresent)
     {
-      IOLog("ApplePS2Controller::setMuxMode = true - version: %x\n" , ver);
+      IOLog("ApplePS2Controller::setMuxMode = true - version: %x\n", ver);
     }
 
     return true;

--- a/VoodooPS2Controller/VoodooPS2Controller.h
+++ b/VoodooPS2Controller/VoodooPS2Controller.h
@@ -150,9 +150,11 @@ class ApplePS2MouseDevice;
 // Constants are from Linux
 // https://github.com/torvalds/linux/blob/c2d7ed9d680fd14aa5486518bd0d0fa5963c6403/drivers/input/serio/i8042.c#L685-L693
 
-#define kDP_EnableMuxCmd1       0xF0
-#define kDP_EnableMuxCmd2       0x56
+#define kDP_MuxCmd              0xF0
+#define kDP_EnableMuxCmd1       0x56
 #define kDP_GetMuxVersion       0xA4
+#define kDP_DisableMuxCmd1      0xF6
+#define kDP_DisableMuxCmd2      0xA5
 
 #if DEBUGGER_SUPPORT
 // Definitions for our internal keyboard queue (holds keys processed by the
@@ -270,7 +272,7 @@ private:
   bool   				   _suppressTimeout {false};
   int                      _wakedelay {10};
   bool                     _mouseWakeFirst {false};
-  bool                     _mux_present {false};
+  bool                     _muxPresent {false};
   IOCommandGate*           _cmdGate {nullptr};
 #if WATCHDOG_TIMER
   IOTimerEventSource*      _watchdogTimer {nullptr};
@@ -300,7 +302,7 @@ private:
   virtual void  writeCommandPort(UInt8 byte);
   virtual void  writeDataPort(UInt8 byte);
   void resetController(void);
-  bool hasMux(void);
+  bool setMuxMode(bool);
     
   static void interruptHandlerMouse(OSObject*, void* refCon, IOService*, int);
   static void interruptHandlerKeyboard(OSObject*, void* refCon, IOService*, int);

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -387,7 +387,7 @@ void ApplePS2SynapticsTouchPad::queryCapabilities()
         
         if (buf3[1] & 0x40)
         {
-            IOLog("VoodooPS2Trackpad: Trackpad supports SMBus operation");
+            IOLog("VoodooPS2Trackpad: Trackpad supports Intertouch/SMBus operation\n");
             setProperty("Intertouch Support", kOSBooleanTrue);
         }
     }


### PR DESCRIPTION
Main bug fix here is allowing the power action to be ran for all mice.
I also removed some snake casing I put in with my last PR.

I added a way to disable mux mode, I'm not really sure this is needed though and commented it out for now. The version tested in https://github.com/acidanthera/bugtracker/issues/1801 had this not commented out. I'm waiting on tests for someone having a similar issue, though now we're running into strange interactions with VoodooRMI in our gitter.

My plan is to get this in for this upcoming release, even if we don't figure out the VRMI issue. I'll undraft by Friday if we don't figure it out.