### PR TITLE
Only set _muxPresent on boot

### DIFF
--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -541,7 +541,7 @@ bool ApplePS2Controller::start(IOService * provider)
   if (_resetControllerFlag & RESET_CONTROLLER_ON_BOOT) {
     resetController(false);
   }
-  
+
   //
   // Use a spin lock to protect the client async request queue.
   //
@@ -1882,7 +1882,9 @@ void ApplePS2Controller::setPowerStateGated( UInt32 powerState )
         {
           resetController(true);
         }
+
 #endif // FULL_INIT_AFTER_WAKE
+
 
         //
         // Transition from Sleep state to Working state in 4 stages.

--- a/VoodooPS2Controller/VoodooPS2Controller.h
+++ b/VoodooPS2Controller/VoodooPS2Controller.h
@@ -303,6 +303,8 @@ private:
   virtual void  writeDataPort(UInt8 byte);
   void resetController(void);
   bool setMuxMode(bool);
+  void flushDataPort(void);
+  void resetDevices(void);
     
   static void interruptHandlerMouse(OSObject*, void* refCon, IOService*, int);
   static void interruptHandlerKeyboard(OSObject*, void* refCon, IOService*, int);

--- a/VoodooPS2Controller/VoodooPS2Controller.h
+++ b/VoodooPS2Controller/VoodooPS2Controller.h
@@ -301,7 +301,7 @@ private:
   virtual UInt8 readDataPort(size_t port);
   virtual void  writeCommandPort(UInt8 byte);
   virtual void  writeDataPort(UInt8 byte);
-  void resetController(void);
+  void resetController(bool);
   bool setMuxMode(bool);
   void flushDataPort(void);
   void resetDevices(void);


### PR DESCRIPTION
Fixes https://github.com/acidanthera/bugtracker/issues/1814

Makes sure that we can't enter mux mode except on boot, as otherwise panics can occur and other weird things can happen.