### PR TITLE
Send power and new SMBus device messages

### DIFF
--- a/VoodooPS2Controller/ApplePS2Device.cpp
+++ b/VoodooPS2Controller/ApplePS2Device.cpp
@@ -181,6 +181,31 @@ IOReturn ApplePS2Device::dispatchMessage(int message, void *data)
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+IOReturn ApplePS2Device::attemptSMBusMessage(UInt8 addrPrim, OSDictionary *data)
+{
+    IOReturn ret = kIOReturnNoDevice;
+    const OSString *prot = OSString::withCString("SMBus");
+    const OSNumber *addr = OSNumber::withNumber(addrPrim, 8);
+    OSDictionary *msg = OSDictionary::withCapacity(1);
+    if (data != nullptr && msg != nullptr &&
+        prot != nullptr && addr != nullptr) {
+        
+        msg->setObject("DeviceProtocol", prot);
+        msg->setObject("DeviceAddress", addr);
+        msg->setObject("DeviceData", data);
+        
+        ret = _controller->dispatchMessage(kPS2C_deviceDiscovered, msg);
+    }
+    
+    OSSafeReleaseNULL(prot);
+    OSSafeReleaseNULL(msg);
+    OSSafeReleaseNULL(addr);
+    
+    return ret == kIOReturnSuccess;
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
 ApplePS2Controller* ApplePS2Device::getController()
 {
     return _controller;

--- a/VoodooPS2Controller/ApplePS2Device.cpp
+++ b/VoodooPS2Controller/ApplePS2Device.cpp
@@ -201,7 +201,7 @@ IOReturn ApplePS2Device::attemptSMBusMessage(UInt8 addrPrim, OSDictionary *data)
     OSSafeReleaseNULL(msg);
     OSSafeReleaseNULL(addr);
     
-    return ret == kIOReturnSuccess;
+    return ret;
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/VoodooPS2Controller/ApplePS2Device.cpp
+++ b/VoodooPS2Controller/ApplePS2Device.cpp
@@ -174,9 +174,9 @@ void ApplePS2Device::uninstallPowerControlAction()
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-void ApplePS2Device::dispatchMessage(int message, void *data)
+IOReturn ApplePS2Device::dispatchMessage(int message, void *data)
 {
-    _controller->dispatchMessage(message, data);
+    return _controller->dispatchMessage(message, data);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -605,6 +605,7 @@ public:
 
     // Messaging
     virtual IOReturn dispatchMessage(int message, void *data);
+    virtual IOReturn attemptSMBusMessage(UInt8, OSDictionary *);
 
     // Exclusive access (command byte contention)
 

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -511,6 +511,7 @@ typedef void (*PS2PowerControlAction)(void * target, UInt32 whatToDo);
 
 // Published property for devices to express interest in receiving messages
 #define kDeliverNotifications   "RM,deliverNotifications"
+#define kControlNotifications   "PS2,controlNotifications"
 
 // Published property for device nub port location
 #define kPortKey    "Port Num"
@@ -528,15 +529,16 @@ enum
 
     kPS2M_resetTouchpad = iokit_vendor_specific_msg(151),        // Force touchpad reset (data is int*)
     
-    // from trackpad on I2C/SMBus
-    kPS2M_SMBusStart = iokit_vendor_specific_msg(152),          // Reset, disable PS2 comms to not interfere with SMBus comms
-    
     // from sensor (such as yoga mode indicator) to keyboard
     kPS2K_setKeyboardStatus = iokit_vendor_specific_msg(200),   // set disable/enable keyboard (data is bool*)
     kPS2K_getKeyboardStatus = iokit_vendor_specific_msg(201),   // get disable/enable keyboard (data is bool*)
 
     // from OEM ACPI (WMI) events to keyboard
     kPS2K_notifyKeystroke = iokit_vendor_specific_msg(202),     // notify of key press (data is PS2KeyInfo*), in the opposite direction of kPS2M_notifyKeyPressed
+    
+    // To SMBus controllers
+    kPS2C_deviceDiscovered = iokit_vendor_specific_msg(300),    // SMBus device discovered on PS2 side, try to init SMBus side
+    kPS2C_wakeCompleted = iokit_vendor_specific_msg(301),       // PS2 Wakeup completed
 };
 
 typedef struct PS2KeyInfo
@@ -602,7 +604,7 @@ public:
     virtual void powerAction(UInt32);
 
     // Messaging
-    virtual void dispatchMessage(int message, void *data);
+    virtual IOReturn dispatchMessage(int message, void *data);
 
     // Exclusive access (command byte contention)
 

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -2031,7 +2031,6 @@ IOReturn ApplePS2Controller::dispatchControlGated(int* message, void* data)
     
     if (i != NULL) {
         while (IOService* service = OSDynamicCast(IOService, i->getNextObject())) {
-            IOLog("PS2Controller: Sending message to device %s\n", service->getName());
             IOReturn ret = service->message(*message, this, data);
             if (ret == kIOReturnSuccess  /* Correct controller, successful init */ ||
                 ret == kIOReturnNoDevice /* Correct controller, failed to init */) {
@@ -2051,7 +2050,6 @@ IOReturn ApplePS2Controller::dispatchMessageGated(int* message, void* data)
 {
     if (*message == kPS2C_deviceDiscovered ||
         *message == kPS2C_wakeCompleted) {
-      IOLog("PS2Controller: DeviceDiscovered\n");
         return dispatchControlGated(message, data);
     } else {
         dispatchNotifictionGated(message, data);

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -2027,10 +2027,11 @@ void ApplePS2Controller::dispatchNotifictionGated(int* message, void* data)
 
 IOReturn ApplePS2Controller::dispatchControlGated(int* message, void* data)
 {
-    OSCollectionIterator* i = OSCollectionIterator::withCollection(_notificationServices);
+    OSCollectionIterator* i = OSCollectionIterator::withCollection(_controllerServices);
     
     if (i != NULL) {
         while (IOService* service = OSDynamicCast(IOService, i->getNextObject())) {
+            IOLog("PS2Controller: Sending message to device %s\n", service->getName());
             IOReturn ret = service->message(*message, this, data);
             if (ret == kIOReturnSuccess  /* Correct controller, successful init */ ||
                 ret == kIOReturnNoDevice /* Correct controller, failed to init */) {
@@ -2050,6 +2051,7 @@ IOReturn ApplePS2Controller::dispatchMessageGated(int* message, void* data)
 {
     if (*message == kPS2C_deviceDiscovered ||
         *message == kPS2C_wakeCompleted) {
+      IOLog("PS2Controller: DeviceDiscovered\n");
         return dispatchControlGated(message, data);
     } else {
         dispatchNotifictionGated(message, data);

--- a/VoodooPS2Controller/VoodooPS2Controller.h
+++ b/VoodooPS2Controller/VoodooPS2Controller.h
@@ -256,6 +256,7 @@ private:
   IONotifier*              _terminateNotify {nullptr};
     
   OSSet*                   _notificationServices {nullptr};
+  OSSet*                   _controllerServices {nullptr};
     
 #if DEBUGGER_SUPPORT
   IOSimpleLock *           _controllerLock {nullptr};       // mach simple spin lock
@@ -282,6 +283,7 @@ private:
 #endif
   OSDictionary*            _rmcfCache {nullptr};
   const OSSymbol*          _deliverNotification {nullptr};
+  const OSSymbol*          _controlNotification {nullptr};
 
   int                      _resetControllerFlag {RESET_CONTROLLER_ON_BOOT | RESET_CONTROLLER_ON_WAKEUP};
 
@@ -318,7 +320,9 @@ private:
   void notificationHandlerTerminateGated(IOService * newService, IONotifier * notifier);
   bool notificationHandlerTerminate(void * refCon, IOService * newService, IONotifier * notifier);
 
-  void dispatchMessageGated(int* message, void* data);
+  void dispatchNotifictionGated(int* message, void* data);
+  IOReturn dispatchControlGated(int* message, void* data);
+  IOReturn dispatchMessageGated(int* message, void* data);
     
   static void setPowerStateCallout(thread_call_param_t param0,
                                    thread_call_param_t param1);
@@ -358,7 +362,7 @@ public:
   IOReturn setPowerState(unsigned long powerStateOrdinal,
                                  IOService *   policyMaker) override;
     
-  virtual void dispatchMessage(int message, void* data);
+  virtual IOReturn dispatchMessage(int message, void* data);
     
   IOReturn setProperties(OSObject* props) override;
   virtual void lock();

--- a/VoodooPS2Trackpad/VoodooPS2Elan.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2Elan.cpp
@@ -233,6 +233,8 @@ bool ApplePS2Elan::start(IOService *provider) {
     // When using SMBus, make sure power/interrupt handlers aren't set
     // Don't recieve notifications to reset or mess with trackpad as well
     if (attemptSMBusStart()) {
+        setName("Elans SMBus Device");
+        INFO_LOG("%s: Found Elans SMBus device! Skip Power/Interrupt install\n", getName());
         return true;
     }
 

--- a/VoodooPS2Trackpad/VoodooPS2Elan.h
+++ b/VoodooPS2Trackpad/VoodooPS2Elan.h
@@ -155,6 +155,8 @@ struct virtual_finger_state {
         ((((fw_version) & 0x0f2000) == 0x0f2000) && \
          ((fw_version) & 0x0000ff) > 0)
 
+#define ETP_SMBUS_ADDR 0x15
+
 /*
  * The base position for one finger, v4 hardware
  */
@@ -318,6 +320,7 @@ private:
     void sendTouchData();
     void resetMouse();
     void setTouchPadEnable(bool enable);
+    bool attemptSMBusStart();
 
     static MT2FingerType GetBestFingerType(int i);
 

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -445,7 +445,6 @@ void ApplePS2SynapticsTouchPad::queryCapabilities()
     setProperty(VOODOO_INPUT_PHYSICAL_MAX_Y_KEY, physical_max_y, 32);
 
     setProperty(VOODOO_INPUT_TRANSFORM_KEY, 0ull, 32);
-    setProperty("VoodooInputSupported", kOSBooleanTrue);
     
     INFO_LOG("VoodooPS2Trackpad: logical %dx%d-%dx%d physical_max %dx%d upmm %dx%d",
           logical_min_x, logical_min_y,
@@ -582,6 +581,12 @@ bool ApplePS2SynapticsTouchPad::start( IOService * provider )
         registerService();
         return true;
     }
+    
+    //
+    // Delay adding VoodooInputSupported property as it's not needed with SMBus
+    //
+    
+    setProperty("VoodooInputSupported", kOSBooleanTrue);
     
     //
     // Set the touchpad mode byte, which will also...

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
@@ -199,6 +199,7 @@ struct virtual_finger_state {
 #define X_MAX_POSITIVE 8176
 #define Y_MAX_POSITIVE 8176
 
+#define SYNAPTICS_SMBUS_ADDR 0x2C
 
 #define kPacketLength 6
 

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
@@ -304,6 +304,7 @@ private:
     bool _extendedwmode {false}, _extendedwmodeSupported {false};
 
     // Capabilities for SMBus
+    bool supportsIntertouch {false};
     bool trackstickButtons {false};
     
     // normal state
@@ -312,7 +313,6 @@ private:
     uint64_t keytime {0};
     UInt16 keycode {0};
     bool ignoreall {false};
-    bool otherBusInUse {false}; // Trackpad being used over SMBus/I2C
 #ifdef SIMULATE_PASSTHRU
 	UInt32 trackbuttons {0};
 #endif
@@ -376,6 +376,7 @@ private:
     bool setTouchpadLED(UInt8 touchLED);
     bool setTouchpadModeByte(); // set based on state
     void initTouchPad();
+    bool attemptSMBusStart();
     bool setModeByte(UInt8 modeByteValue);
     bool setModeByte(); // set based on state
 

--- a/VoodooPS2Trackpad/VoodooPS2Trackpad-Info.plist
+++ b/VoodooPS2Trackpad/VoodooPS2Trackpad-Info.plist
@@ -156,8 +156,6 @@
 					<integer>1000</integer>
 				</dict>
 			</dict>
-			<key>RM,deliverNotifications</key>
-			<true/>
 		</dict>
 		<key>Native Multitouch Engine</key>
 		<dict>
@@ -411,8 +409,6 @@
 			</dict>
 			<key>ProductID</key>
 			<integer>547</integer>
-			<key>RM,deliverNotifications</key>
-			<true/>
 			<key>VendorID</key>
 			<integer>1452</integer>
 		</dict>


### PR DESCRIPTION
This fixes race conditions which were occurring in VoodooRMI more commonly since mux support was added previously. If ApplePS2Synaptics figures out that Intertouch is supported, it can attempt to wake the trackpad over SMBus without interference over PS2. If the trackpad starts up over SMBus, ApplePS2Synaptics will skip installing power and interrupt handlers, and change its name. VoodooPS2Controller will also send a notification when done waking from sleep.

The notifications are used to create nubs in VoodooSMBus, and start matching synchronously. VSMB will return a success or failure, allowing the trackpad to work over PS2 if either VSMB or VRMI doesn't exist, or SMBus start fails. As VRMI matches synchronously, hard coded delays and matching notifiers can be removed from VRMI. The waking from sleep notification also removes hard coded wake delays in VRMI.

This should be easily adaptable for Elans too:
https://github.com/torvalds/linux/blob/master/drivers/input/mouse/elantech.c#L1877

Note: Not tested yet, nor is the SMBus side written yet

Todo:
- [x] Elans
- [ ] Properties to force PS2 or SMBus
