### PR TITLE
VoodooPS2Elan - Fixed trackpoint scrolling in the wrong direction

### DIFF
--- a/VoodooPS2Trackpad/VoodooPS2Elan.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2Elan.cpp
@@ -1884,7 +1884,7 @@ void ApplePS2Elan::elantechReportTrackpoint() {
     keytime = timestamp_ns;
 
     if (trackpointScrolling) {
-        dispatchScrollWheelEvent(dx, dy, 0, timestamp);
+        dispatchScrollWheelEvent(dy, dx, 0, timestamp);
     } else {
         dispatchRelativePointerEvent(dx, dy, trackpointRightButton | trackpointLeftButton | trackpointMiddleButton, timestamp);
     }


### PR DESCRIPTION
As reported in this issue: https://github.com/acidanthera/bugtracker/issues/1226 trackpoint (when clicking the middle button) scrolls, but in the wrong direction. Reversing arguments provided to "dispatchScrollWheelEvent" function fixes the issue.

The arguments are already reversed both in [VoodooPS2ALPS](https://github.com/acidanthera/VoodooPS2/blob/f5e40698ec87d39c9c6f24ea76fe6932cec2659b/VoodooPS2Trackpad/VoodooPS2ALPSGlidePoint.cpp#L964) and in [VoodooPS2Synaptics](https://github.com/acidanthera/VoodooPS2/blob/f5e40698ec87d39c9c6f24ea76fe6932cec2659b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp#L1003). Therefore, the same should apply to trackpoint implementation for elan trackpads.

This fixes the first point of Trackpad Elan meta issue: https://github.com/acidanthera/bugtracker/issues/1192