### PR TITLE
set IOProbeScore of ALPS touchpads to 1500

### DIFF
--- a/VoodooPS2Trackpad/VoodooPS2Trackpad-Info.plist
+++ b/VoodooPS2Trackpad/VoodooPS2Trackpad-Info.plist
@@ -29,7 +29,7 @@
 			<key>IOClass</key>
 			<string>ApplePS2ALPSGlidePoint</string>
 			<key>IOProbeScore</key>
-			<integer>6000</integer>
+			<integer>1500</integer>
 			<key>IOProviderClass</key>
 			<string>ApplePS2MouseDevice</string>
 			<key>Platform Profile</key>


### PR DESCRIPTION
For some reason, changing the IOProbeScore to 1500 fixes the touchpad on newer models. Someone on Discord with V7 touchpad messaged me that the trackpad was being recognized, but there was no input on macOS, which is the same as on V8 touchpads. After I told him to change the IOProbeScore to 1500, he told me that fixed it. V8 users also confirmed that 1500 fixes the touchpad. @realizelol also got his V3 touchpad working at 1500.

Seems like VoodooPS2 2.2.9 can be released on the next release date (which I think is today?)