### PR TITLE
Replace kDP_SetDefaultsAndDisable with kDP_SetDefaults to fix keyboard disabled in some UEFI

### DIFF
--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -1923,7 +1923,12 @@ void ApplePS2Keyboard::setKeyboardEnable(bool enable)
     // (keyboard enable/disable command)
     TPS2Request<2> request;
     request.commands[0].command = kPS2C_WriteDataPort;
-    request.commands[0].inOrOut = enable ? kDP_Enable : kDP_SetDefaultsAndDisable;
+    
+    if(_kbd_fixdisable)
+        request.commands[0].inOrOut = enable ? kDP_Enable : kDP_SetDefaults;
+    else
+        request.commands[0].inOrOut = enable ? kDP_Enable : kDP_SetDefaultsAndDisable;
+    
     request.commands[1].command = kPS2C_ReadDataPortAndCompare;
     request.commands[1].inOrOut = kSC_Acknowledge;
     request.commandsCount = 2;
@@ -2209,6 +2214,10 @@ void ApplePS2Keyboard::setDevicePowerState( UInt32 whatToDo )
 
 void ApplePS2Keyboard::initKeyboard()
 {
+    int kbd_fixdisable = 0;
+    PE_parse_boot_argn("kbd_fixdisable", &kbd_fixdisable, sizeof(kbd_fixdisable));
+    if (kbd_fixdisable) _kbd_fixdisable = true;
+    
     //
     // Reset the keyboard to its default state.
     //

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -1923,12 +1923,7 @@ void ApplePS2Keyboard::setKeyboardEnable(bool enable)
     // (keyboard enable/disable command)
     TPS2Request<2> request;
     request.commands[0].command = kPS2C_WriteDataPort;
-    
-    if(_kbd_fixdisable)
-        request.commands[0].inOrOut = enable ? kDP_Enable : kDP_SetDefaults;
-    else
-        request.commands[0].inOrOut = enable ? kDP_Enable : kDP_SetDefaultsAndDisable;
-    
+    request.commands[0].inOrOut = enable ? kDP_Enable : kDP_SetDefaults;
     request.commands[1].command = kPS2C_ReadDataPortAndCompare;
     request.commands[1].inOrOut = kSC_Acknowledge;
     request.commandsCount = 2;

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.cpp
@@ -2209,10 +2209,6 @@ void ApplePS2Keyboard::setDevicePowerState( UInt32 whatToDo )
 
 void ApplePS2Keyboard::initKeyboard()
 {
-    int kbd_fixdisable = 0;
-    PE_parse_boot_argn("kbd_fixdisable", &kbd_fixdisable, sizeof(kbd_fixdisable));
-    if (kbd_fixdisable) _kbd_fixdisable = true;
-    
     //
     // Reset the keyboard to its default state.
     //

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -116,9 +116,6 @@ private:
     
     // Toggle keyboard input along with touchpad when Windows+printscreen is pressed
     bool                        _disableInput;
-
-    // Fix for BIOS which don't enable the keyboard on reboot, default is not to fix
-    bool                        _kbd_fixdisable {false};
     
     // macro processing
     OSData**                    _macroTranslation;

--- a/VoodooPS2Keyboard/VoodooPS2Keyboard.h
+++ b/VoodooPS2Keyboard/VoodooPS2Keyboard.h
@@ -116,6 +116,9 @@ private:
     
     // Toggle keyboard input along with touchpad when Windows+printscreen is pressed
     bool                        _disableInput;
+
+    // Fix for BIOS which don't enable the keyboard on reboot, default is not to fix
+    bool                        _kbd_fixdisable {false};
     
     // macro processing
     OSData**                    _macroTranslation;


### PR DESCRIPTION
Add boot_argn to fix keyboard disabled in some UEFI BIOS after a reboot. https://github.com/acidanthera/bugtracker/issues/1838

kbd_fixdisable=1