### PR TITLE
kernel parameter for kbd(port 0) only mode

### DIFF
--- a/VoodooPS2Controller/VoodooPS2Controller.h
+++ b/VoodooPS2Controller/VoodooPS2Controller.h
@@ -284,6 +284,7 @@ private:
   const OSSymbol*          _deliverNotification {nullptr};
 
   int                      _resetControllerFlag {RESET_CONTROLLER_ON_BOOT | RESET_CONTROLLER_ON_WAKEUP};
+  bool                     _kbdOnly {0};
 
   virtual PS2InterruptResult _dispatchDriverInterrupt(size_t port, UInt8 data);
   virtual void dispatchDriverInterrupt(size_t port, UInt8 data);


### PR DESCRIPTION
adds kernel parameter `ps2kbdonly` which keeps mouse clock line disabled

ps2+smbus elan touchpad on thinkpad x380 yoga would get voodoops2 stuck after suspend and wake when used with voodoosmbus, disabling keyboard input as a result

disabling aux would allow the keyboard port to continue functioning, while the trackpad and trackpoint would continue to function with voodoosmbus