### PR TITLE
Fix close when unloading VoodooInput

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 VoodooPS2 Changelog
 ============================
 #### v2.3.4
-- Fixed device count detection when `ps2rst=0` is set.
+- Fixed device count detection when `ps2rst=0` is set
+- Fixed handleClose not being called by VoodooInput
 
 #### v2.3.3
 - Fixed rapidly opening pages in browsers while scrolling with the trackpoint

--- a/VoodooPS2Trackpad/VoodooPS2ALPSGlidePoint.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2ALPSGlidePoint.cpp
@@ -313,12 +313,21 @@ bool ApplePS2ALPSGlidePoint::handleOpen(IOService *forClient, IOOptionBits optio
 
         return true;
     }
-    return super::handleOpen(forClient, options, arg);
+    return false;
+}
+
+bool ApplePS2ALPSGlidePoint::handleIsOpen(const IOService *forClient) const {
+    if (forClient == nullptr) {
+        return voodooInputInstance != nullptr;
+    } else {
+        return voodooInputInstance == forClient;
+    }
 }
 
 void ApplePS2ALPSGlidePoint::handleClose(IOService *forClient, IOOptionBits options) {
-    OSSafeReleaseNULL(voodooInputInstance);
-    super::handleClose(forClient, options);
+    if (forClient == voodooInputInstance) {
+        OSSafeReleaseNULL(voodooInputInstance);
+    }
 }
 
 bool ApplePS2ALPSGlidePoint::start( IOService * provider ) {

--- a/VoodooPS2Trackpad/VoodooPS2ALPSGlidePoint.h
+++ b/VoodooPS2Trackpad/VoodooPS2ALPSGlidePoint.h
@@ -441,6 +441,7 @@ private:
     bool resetMouse();
     bool handleOpen(IOService *forClient, IOOptionBits options, void *arg) override;
     void handleClose(IOService *forClient, IOOptionBits options) override;
+    bool handleIsOpen(const IOService *forClient) const override;
     PS2InterruptResult interruptOccurred(UInt8 data);
     void packetReady();
     virtual bool deviceSpecificInit();

--- a/VoodooPS2Trackpad/VoodooPS2Elan.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2Elan.cpp
@@ -183,12 +183,21 @@ bool ApplePS2Elan::handleOpen(IOService *forClient, IOOptionBits options, void *
         return true;
     }
 
-    return super::handleOpen(forClient, options, arg);
+    return false;
+}
+
+bool ApplePS2Elan::handleIsOpen(const IOService *forClient) const {
+    if (forClient == nullptr) {
+        return voodooInputInstance != nullptr;
+    } else {
+        return voodooInputInstance == forClient;
+    }
 }
 
 void ApplePS2Elan::handleClose(IOService *forClient, IOOptionBits options) {
-    OSSafeReleaseNULL(voodooInputInstance);
-    super::handleClose(forClient, options);
+    if (forClient == voodooInputInstance) {
+        OSSafeReleaseNULL(voodooInputInstance);
+    }
 }
 
 bool ApplePS2Elan::start(IOService *provider) {

--- a/VoodooPS2Trackpad/VoodooPS2Elan.h
+++ b/VoodooPS2Trackpad/VoodooPS2Elan.h
@@ -281,6 +281,7 @@ private:
 
     bool handleOpen(IOService *forClient, IOOptionBits options, void *arg) override;
     void handleClose(IOService *forClient, IOOptionBits options) override;
+    bool handleIsOpen(const IOService *forClient) const override;
 
     void setParamPropertiesGated(OSDictionary *dict);
     void injectVersionDependentProperties(OSDictionary *dict);

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -395,8 +395,11 @@ bool ApplePS2SynapticsTouchPad::handleOpen(IOService *forClient, IOOptionBits op
 }
 
 bool ApplePS2SynapticsTouchPad::handleIsOpen(const IOService *forClient) const {
-    if (forClient == nullptr) return voodooInputInstance != nullptr;
-    else return voodooInputInstance == forClient;
+    if (forClient == nullptr) {
+        return voodooInputInstance != nullptr;
+    } else {
+        return voodooInputInstance == forClient;
+    }
 }
 
 void ApplePS2SynapticsTouchPad::handleClose(IOService *forClient, IOOptionBits options) {

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -391,12 +391,18 @@ bool ApplePS2SynapticsTouchPad::handleOpen(IOService *forClient, IOOptionBits op
         return true;
     }
 
-    return super::handleOpen(forClient, options, arg);
+    return false;
+}
+
+bool ApplePS2SynapticsTouchPad::handleIsOpen(const IOService *forClient) const {
+    if (forClient == nullptr) return voodooInputInstance != nullptr;
+    else return voodooInputInstance == forClient;
 }
 
 void ApplePS2SynapticsTouchPad::handleClose(IOService *forClient, IOOptionBits options) {
-    OSSafeReleaseNULL(voodooInputInstance);
-    super::handleClose(forClient, options);
+    if (forClient == voodooInputInstance) {
+        OSSafeReleaseNULL(voodooInputInstance);
+    }
 }
 
 bool ApplePS2SynapticsTouchPad::start( IOService * provider )

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
@@ -361,6 +361,7 @@ private:
 
     bool handleOpen(IOService *forClient, IOOptionBits options, void *arg) override;
     void handleClose(IOService *forClient, IOOptionBits options) override;
+    virtual bool handleIsOpen(const IOService *forClient) const override;
     
     void setPropertiesGated(OSDictionary* dict);
     void injectVersionDependentProperties(OSDictionary* dict);

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
@@ -361,7 +361,7 @@ private:
 
     bool handleOpen(IOService *forClient, IOOptionBits options, void *arg) override;
     void handleClose(IOService *forClient, IOOptionBits options) override;
-    virtual bool handleIsOpen(const IOService *forClient) const override;
+    bool handleIsOpen(const IOService *forClient) const override;
     
     void setPropertiesGated(OSDictionary* dict);
     void injectVersionDependentProperties(OSDictionary* dict);


### PR DESCRIPTION
This change allows VoodooInput to be unloaded in Catalina and earlier. Currently, VoodooPS2 retains a reference to VoodooInput, which prevents it from being unloaded. The main cause is that VoodooInput checks `isOpen` to see if it should close from the provider. This fails as the default implementation of `handleIsOpen` only checks an internal variable that is set in IOService::handleOpen.