### PR TITLE
Fix reset flags

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 VoodooPS2 Changelog
 ============================
+#### v2.3.4
+- Fixed device count detection when `ps2rst=0` is set.
+
 #### v2.3.3
 - Fixed rapidly opening pages in browsers while scrolling with the trackpoint
 - Fixed buttons on various trackpads (especially those without trackpoints attached)

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -415,30 +415,6 @@ void ApplePS2Controller::resetController(bool wakeup)
     writeCommandPort(kCP_SetCommandByte);
     writeDataPort(commandByte);
     DEBUG_LOG("%s: new commandByte = %02x\n", getName(), commandByte);
-  
-    if (wakeup && _muxPresent)
-    {
-        setMuxMode(true);
-    }
-    else if (!wakeup)
-    {
-        if (!_kbdOnly){
-            _muxPresent = setMuxMode(true);
-            _nubsCount = _muxPresent ? kPS2MuxMaxIdx : kPS2AuxMaxIdx;
-        }else{
-            _muxPresent = false;
-            _nubsCount = 1;
-        }
-    }
-  
-    resetDevices();
-  
-    //
-    // Clear out garbage in the controller's input streams, before starting up
-    // the work loop.
-    //
-  
-    flushDataPort();
 }
 
 // -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -551,6 +527,29 @@ bool ApplePS2Controller::start(IOService * provider)
     resetController(false);
   }
 
+  //
+  // Enable "Active PS/2 Multiplexing" if it exists.
+  // This creates 4 Aux ports which pointing devices may connect to.
+  //
+  
+  if (_kbdOnly) {
+    _muxPresent = false;
+    _nubsCount = 1;
+  } else {
+    _muxPresent = setMuxMode(true);
+    _nubsCount = _muxPresent ? kPS2MuxMaxIdx : kPS2AuxMaxIdx;
+  }
+  
+  //
+  // Reset attached devices and clear out garbage in the controller's input streams,
+  // before starting up the work loop.
+  //
+  
+  if (_resetControllerFlag & RESET_CONTROLLER_ON_BOOT) {
+    resetDevices();
+    flushDataPort();
+  }
+  
   //
   // Use a spin lock to protect the client async request queue.
   //
@@ -1880,7 +1879,18 @@ void ApplePS2Controller::setPowerStateGated( UInt32 powerState )
 
 #endif // FULL_INIT_AFTER_WAKE
 
-
+        if (_muxPresent) {
+          setMuxMode(true);
+        }
+        
+#if FULL_INIT_AFTER_WAKE
+        if (_resetControllerFlag & RESET_CONTROLLER_ON_WAKEUP)
+        {
+          resetDevices();
+          flushDataPort();
+        }
+#endif // FULL_INIT_AFTER_WAKE
+        
         //
         // Transition from Sleep state to Working state in 4 stages.
         //

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -369,7 +369,7 @@ IOReturn ApplePS2Controller::setProperties(OSObject* props)
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-void ApplePS2Controller::resetController(bool wakeup)
+void ApplePS2Controller::resetController()
 {
     _suppressTimeout = true;
     UInt8 commandByte;
@@ -524,7 +524,7 @@ bool ApplePS2Controller::start(IOService * provider)
     
   PE_parse_boot_argn("ps2rst", &_resetControllerFlag, sizeof(_resetControllerFlag));
   if (_resetControllerFlag & RESET_CONTROLLER_ON_BOOT) {
-    resetController(false);
+    resetController();
   }
 
   //
@@ -1874,7 +1874,7 @@ void ApplePS2Controller::setPowerStateGated( UInt32 powerState )
         
         if (_resetControllerFlag & RESET_CONTROLLER_ON_WAKEUP)
         {
-          resetController(true);
+          resetController();
         }
 
 #endif // FULL_INIT_AFTER_WAKE

--- a/VoodooPS2Controller/VoodooPS2Controller.h
+++ b/VoodooPS2Controller/VoodooPS2Controller.h
@@ -305,7 +305,7 @@ private:
   virtual UInt8 readDataPort(size_t port);
   virtual void  writeCommandPort(UInt8 byte);
   virtual void  writeDataPort(UInt8 byte);
-  void resetController(bool);
+  void resetController(void);
   bool setMuxMode(bool);
   void flushDataPort(void);
   void resetDevices(void);


### PR DESCRIPTION
Reported in #42 , not having resetController run at startup causes issues. This fixes it by always running the logic which detects active multiplexing and setting nubsCount.