### PR TITLE
SMBus Companion Devices

### DIFF
--- a/VoodooPS2Controller.xcodeproj/project.pbxproj
+++ b/VoodooPS2Controller.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		CE8DA1C6251839B7008C44E8 /* libkmod.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE8DA1C4251839B2008C44E8 /* libkmod.a */; };
 		CE8DA1C7251839B9008C44E8 /* libkmod.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE8DA1C4251839B2008C44E8 /* libkmod.a */; };
 		CE8DA1CC251839BC008C44E8 /* libkmod.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE8DA1C4251839B2008C44E8 /* libkmod.a */; };
+		EE914A902C952F0D0023CFE0 /* VoodooPS2SMBusDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EE914A8E2C952F0D0023CFE0 /* VoodooPS2SMBusDevice.cpp */; };
+		EE914A912C952F0D0023CFE0 /* VoodooPS2SMBusDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = EE914A8F2C952F0D0023CFE0 /* VoodooPS2SMBusDevice.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -131,6 +133,8 @@
 		EDD95559208E2B640031D99E /* SSDT-Thinkpad_Clickpad.dsl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "SSDT-Thinkpad_Clickpad.dsl"; sourceTree = "<group>"; };
 		EDD9555A208E2E7A0031D99E /* SSDT-Thinkpad_Trackpad.dsl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "SSDT-Thinkpad_Trackpad.dsl"; sourceTree = "<group>"; };
 		EDD970FD1FD0B826004CCFFD /* SSDT-HP-FixLidSleep.dsl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "SSDT-HP-FixLidSleep.dsl"; sourceTree = "<group>"; };
+		EE914A8E2C952F0D0023CFE0 /* VoodooPS2SMBusDevice.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VoodooPS2SMBusDevice.cpp; sourceTree = "<group>"; };
+		EE914A8F2C952F0D0023CFE0 /* VoodooPS2SMBusDevice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VoodooPS2SMBusDevice.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -287,6 +291,8 @@
 				84833FB0161B62A900845294 /* VoodooPS2SynapticsTouchPad.h */,
 				84833FAF161B62A900845294 /* VoodooPS2SynapticsTouchPad.cpp */,
 				4CC27EB2251FBC7700824FE1 /* VoodooPS2TrackpadCommon.h */,
+				EE914A8F2C952F0D0023CFE0 /* VoodooPS2SMBusDevice.h */,
+				EE914A8E2C952F0D0023CFE0 /* VoodooPS2SMBusDevice.cpp */,
 				84167857161B56C4002C60E6 /* Supporting Files */,
 			);
 			path = VoodooPS2Trackpad;
@@ -393,6 +399,7 @@
 				356B896323007F4F0042F30F /* VoodooInputEvent.h in Headers */,
 				9828A93024A2B6C200550FAA /* VoodooPS2Elan.h in Headers */,
 				356B896223007F4F0042F30F /* VoodooInputMessages.h in Headers */,
+				EE914A912C952F0D0023CFE0 /* VoodooPS2SMBusDevice.h in Headers */,
 				356B896423007F4F0042F30F /* VoodooInputTransducer.h in Headers */,
 				84833FB2161B62A900845294 /* VoodooPS2ALPSGlidePoint.h in Headers */,
 				356B896523007F4F0042F30F /* MultitouchHelpers.h in Headers */,
@@ -653,6 +660,7 @@
 				84833FB1161B62A900845294 /* VoodooPS2ALPSGlidePoint.cpp in Sources */,
 				9828A92F24A2B6C200550FAA /* VoodooPS2Elan.cpp in Sources */,
 				84833FB3161B62A900845294 /* VoodooPS2SentelicFSP.cpp in Sources */,
+				EE914A902C952F0D0023CFE0 /* VoodooPS2SMBusDevice.cpp in Sources */,
 				84833FB5161B62A900845294 /* VoodooPS2SynapticsTouchPad.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/VoodooPS2Controller/ApplePS2Device.cpp
+++ b/VoodooPS2Controller/ApplePS2Device.cpp
@@ -181,6 +181,13 @@ void ApplePS2Device::dispatchMessage(int message, void *data)
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+IOReturn ApplePS2Device::startSMBusCompanion(OSDictionary *companionData, UInt8 smbusAddr)
+{
+    return _controller->startSMBusCompanion(companionData, smbusAddr);
+}
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
 ApplePS2Controller* ApplePS2Device::getController()
 {
     return _controller;

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -516,6 +516,8 @@ typedef void (*PS2PowerControlAction)(void * target, UInt32 whatToDo);
 // Published property for devices to express interest in receiving messages
 #define kDeliverNotifications   "RM,deliverNotifications"
 
+#define kSmbusCompanion         "VoodooSMBusCompanionDevice"
+
 // Published property for device nub port location
 #define kPortKey    "Port Num"
 

--- a/VoodooPS2Controller/ApplePS2Device.h
+++ b/VoodooPS2Controller/ApplePS2Device.h
@@ -532,9 +532,6 @@ enum
 
     kPS2M_resetTouchpad = iokit_vendor_specific_msg(151),        // Force touchpad reset (data is int*)
     
-    // from trackpad on I2C/SMBus
-    kPS2M_SMBusStart = iokit_vendor_specific_msg(152),          // Reset, disable PS2 comms to not interfere with SMBus comms
-    
     // from sensor (such as yoga mode indicator) to keyboard
     kPS2K_setKeyboardStatus = iokit_vendor_specific_msg(200),   // set disable/enable keyboard (data is bool*)
     kPS2K_getKeyboardStatus = iokit_vendor_specific_msg(201),   // get disable/enable keyboard (data is bool*)
@@ -607,6 +604,7 @@ public:
 
     // Messaging
     virtual void dispatchMessage(int message, void *data);
+    virtual IOReturn startSMBusCompanion(OSDictionary *companionData, UInt8 smbusAddr);
 
     // Exclusive access (command byte contention)
 

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -2126,7 +2126,7 @@ static OSString* getPlatformOverride(IORegistryEntry* reg, const char* sz)
     return NULL;
 }
 
-static OSString* getPlatformManufacturer(IORegistryEntry* reg)
+static LIBKERN_RETURNS_RETAINED OSString* getPlatformManufacturer(IORegistryEntry* reg)
 {
     // allow override in PS2K ACPI device
     OSString* id = getPlatformOverride(reg, "RM,oem-id");
@@ -2148,7 +2148,7 @@ static OSString* getPlatformManufacturer(IORegistryEntry* reg)
     return OSString::withCStringNoCopy(oemID);
 }
 
-static OSString* getPlatformProduct(IORegistryEntry* reg)
+static LIBKERN_RETURNS_RETAINED OSString* getPlatformProduct(IORegistryEntry* reg)
 {
     // allow override in PS2K ACPI device
     OSString* id = getPlatformOverride(reg, "RM,oem-table-id");

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -280,6 +280,10 @@ bool ApplePS2Controller::init(OSDictionary* dict)
   _deliverNotification = OSSymbol::withCString(kDeliverNotifications);
    if (_deliverNotification == NULL)
 	  return false;
+  
+  _smbusCompanion = OSSymbol::withCString(kSmbusCompanion);
+  if (_smbusCompanion == NULL)
+      return false;
 
   queue_init(&_requestQueue);
 
@@ -747,6 +751,7 @@ void ApplePS2Controller::stop(IOService * provider)
   // Free the RMCF configuration cache
   OSSafeReleaseNULL(_rmcfCache);
   OSSafeReleaseNULL(_deliverNotification);
+  OSSafeReleaseNULL(_smbusCompanion);
 
   // Free the request queue lock and empty out the request queue.
   if (_requestQueueLock)
@@ -2425,14 +2430,11 @@ OSDictionary* ApplePS2Controller::makeConfigurationNode(OSDictionary* list, cons
 }
 
 IOReturn ApplePS2Controller::startSMBusCompanion(OSDictionary *companionData, UInt8 smbusAddr) {
-  const OSSymbol *symbol = OSSymbol::withCString("VoodooSMBusCompanionDevice");
-  IOReturn ret = callPlatformFunction(symbol,
-                              false,
-                              static_cast<void *>(this),
-                              static_cast<void *>(companionData),
-                              reinterpret_cast<void *>(smbusAddr),
-                              nullptr
-                              );
-  OSSafeReleaseNULL(symbol);
+  IOReturn ret = callPlatformFunction(_smbusCompanion,
+                                      false,
+                                      static_cast<void *>(this),
+                                      static_cast<void *>(companionData),
+                                      reinterpret_cast<void *>(smbusAddr),
+                                      nullptr);
   return ret;
 }

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -2426,11 +2426,13 @@ OSDictionary* ApplePS2Controller::makeConfigurationNode(OSDictionary* list, cons
 
 IOReturn ApplePS2Controller::startSMBusCompanion(OSDictionary *companionData, UInt8 smbusAddr) {
   const OSSymbol *symbol = OSSymbol::withCString("VoodooSMBusCompanionDevice");
-  return callPlatformFunction(symbol,
-                              true,
+  IOReturn ret = callPlatformFunction(symbol,
+                              false,
                               static_cast<void *>(this),
                               static_cast<void *>(companionData),
                               reinterpret_cast<void *>(smbusAddr),
                               nullptr
                               );
+  OSSafeReleaseNULL(symbol);
+  return ret;
 }

--- a/VoodooPS2Controller/VoodooPS2Controller.cpp
+++ b/VoodooPS2Controller/VoodooPS2Controller.cpp
@@ -2423,3 +2423,14 @@ OSDictionary* ApplePS2Controller::makeConfigurationNode(OSDictionary* list, cons
 
     return result;
 }
+
+IOReturn ApplePS2Controller::startSMBusCompanion(OSDictionary *companionData, UInt8 smbusAddr) {
+  const OSSymbol *symbol = OSSymbol::withCString("VoodooSMBusCompanionDevice");
+  return callPlatformFunction(symbol,
+                              true,
+                              static_cast<void *>(this),
+                              static_cast<void *>(companionData),
+                              reinterpret_cast<void *>(smbusAddr),
+                              nullptr
+                              );
+}

--- a/VoodooPS2Controller/VoodooPS2Controller.h
+++ b/VoodooPS2Controller/VoodooPS2Controller.h
@@ -371,6 +371,8 @@ public:
   OSDictionary* getConfigurationOverride(IOACPIPlatformDevice* acpi, const char* method);
   OSObject* translateArray(OSArray* array);
   OSObject* translateEntry(OSObject* obj);
+  
+  IOReturn startSMBusCompanion(OSDictionary *companionData, UInt8 smbusAddr);
 };
 
 #endif /* _APPLEPS2CONTROLLER_H */

--- a/VoodooPS2Controller/VoodooPS2Controller.h
+++ b/VoodooPS2Controller/VoodooPS2Controller.h
@@ -282,6 +282,7 @@ private:
 #endif
   OSDictionary*            _rmcfCache {nullptr};
   const OSSymbol*          _deliverNotification {nullptr};
+  const OSSymbol*          _smbusCompanion {nullptr};
 
   int                      _resetControllerFlag {RESET_CONTROLLER_ON_BOOT | RESET_CONTROLLER_ON_WAKEUP};
   bool                     _kbdOnly {0};

--- a/VoodooPS2Trackpad/VoodooPS2SMBusDevice.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SMBusDevice.cpp
@@ -14,17 +14,19 @@ ApplePS2SmbusDevice *ApplePS2SmbusDevice::withReset(bool resetNeeded, OSDictiona
     ApplePS2SmbusDevice *dev = OSTypeAlloc(ApplePS2SmbusDevice);
     
     if (dev == nullptr) {
-        IOLog("ApplePS2SmbusDevice - Could not create PS/2 stub device\n");
+        IOLog("ApplePS2SmbusDevice: Could not create PS/2 stub device\n");
         return nullptr;
     }
     
     if (!dev->init()) {
-        IOLog("ApplePS2SmbusDevice - Could not init PS/2 stub device\n");
+        IOLog("ApplePS2SmbusDevice: Could not init PS/2 stub device\n");
+        OSSafeReleaseNULL(dev);
         return nullptr;
     }
     
     dev->_resetNeeded = resetNeeded;
     dev->_data = data;
+    dev->_data->retain();
     dev->_addr = addr;
     return dev;
 }
@@ -47,6 +49,10 @@ bool ApplePS2SmbusDevice::start(IOService *provider) {
     
     OSSafeReleaseNULL(_data);
     return ret == kIOReturnSuccess;
+}
+
+void ApplePS2SmbusDevice::free() {
+    OSSafeReleaseNULL(_data);
 }
 
 void ApplePS2SmbusDevice::powerAction(uint32_t ordinal) {

--- a/VoodooPS2Trackpad/VoodooPS2SMBusDevice.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SMBusDevice.cpp
@@ -1,0 +1,68 @@
+//
+//  VoodooPS2SMBusDevice.cpp
+//  VoodooPS2Trackpad
+//
+//  Created by Gwydien on 9/13/24.
+//  Copyright © 2024 Acidanthera. All rights reserved.
+//
+
+#include "VoodooPS2SMBusDevice.h"
+
+// Steps
+// 1. If PS/2 Mode, create SMBus node
+// 2. Attempt start. VRMI should have a power dependency on PS/2 controller
+// 3. If SMBus start works, return PS2SmbusDevice
+
+ApplePS2SmbusDevice *ApplePS2SmbusDevice::withReset(bool resetNeeded) {
+    ApplePS2SmbusDevice *dev = OSTypeAlloc(ApplePS2SmbusDevice);
+    
+    if (dev == nullptr) {
+        IOLog("ApplePS2SmbusDevice - Could not create PS/2 stub device\n");
+        return nullptr;
+    }
+    
+    if (!dev->init()) {
+        IOLog("ApplePS2SmbusDevice - Could not init PS/2 stub device\n");
+    }
+    
+    dev->_resetNeeded = resetNeeded;
+    return dev;
+}
+
+bool ApplePS2SmbusDevice::start(IOService *provider) {
+    IOReturn ret = kIOReturnSuccess;
+    
+    _nub = OSDynamicCast(ApplePS2MouseDevice, provider);
+    if (_nub == nullptr) {
+        return false;
+    }
+    
+    if (_resetNeeded) {
+        ret = resetDevice();
+    }
+    
+    _nub->installPowerControlAction(this, OSMemberFunctionCast(PS2PowerControlAction, this, &ApplePS2SmbusDevice::powerAction));
+    return ret == kIOReturnSuccess;
+}
+
+void ApplePS2SmbusDevice::powerAction(uint32_t ordinal) {
+    if (ordinal == kPS2C_EnableDevice && _resetNeeded) {
+        (void) resetDevice();
+    }
+}
+
+IOReturn ApplePS2SmbusDevice::resetDevice() {
+    TPS2Request<> request;
+    request.commands[0].command = kPS2C_SendCommandAndCompareAck;
+    request.commands[0].inOrOut = kDP_SetDefaultsAndDisable;     // F5
+    request.commandsCount = 1;
+    _nub->submitRequestAndBlock(&request);
+    
+    if (request.commandsCount == 1) {
+        DEBUG_LOG("VoodooPS2Trackpad: sending $FF failed: %d\n", request.commandsCount);
+        return kIOReturnError;
+    }
+    
+    return kIOReturnSuccess;
+}
+

--- a/VoodooPS2Trackpad/VoodooPS2SMBusDevice.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SMBusDevice.cpp
@@ -2,11 +2,15 @@
 //  VoodooPS2SMBusDevice.cpp
 //  VoodooPS2Trackpad
 //
-//  Created by Gwydien on 9/13/24.
+//  Created by Avery Black on 9/13/24.
 //  Copyright © 2024 Acidanthera. All rights reserved.
 //
 
 #include "VoodooPS2SMBusDevice.h"
+
+// =============================================================================
+// ApplePS2SmbusDevice Class Implementation
+//
 
 OSDefineMetaClassAndStructors(ApplePS2SmbusDevice, IOService);
 

--- a/VoodooPS2Trackpad/VoodooPS2SMBusDevice.h
+++ b/VoodooPS2Trackpad/VoodooPS2SMBusDevice.h
@@ -30,6 +30,7 @@ public:
     static ApplePS2SmbusDevice *withReset(bool resetNeeded, OSDictionary *data, uint8_t addr);
     
     bool start(IOService *provider) override;
+    void free() override;
     
 private:
     ApplePS2MouseDevice *_nub {nullptr};

--- a/VoodooPS2Trackpad/VoodooPS2SMBusDevice.h
+++ b/VoodooPS2Trackpad/VoodooPS2SMBusDevice.h
@@ -27,13 +27,15 @@ class EXPORT ApplePS2SmbusDevice : public IOService {
     typedef IOService super;
     OSDeclareDefaultStructors(ApplePS2SmbusDevice);
 public:
-    static ApplePS2SmbusDevice *withReset(bool resetNeeded);
+    static ApplePS2SmbusDevice *withReset(bool resetNeeded, OSDictionary *data, uint8_t addr);
     
     bool start(IOService *provider) override;
     
 private:
     ApplePS2MouseDevice *_nub {nullptr};
     bool _resetNeeded {false};
+    OSDictionary *_data {nullptr};
+    uint8_t _addr{0};
     
     IOReturn resetDevice();
     void powerAction(uint32_t ordinal);

--- a/VoodooPS2Trackpad/VoodooPS2SMBusDevice.h
+++ b/VoodooPS2Trackpad/VoodooPS2SMBusDevice.h
@@ -1,0 +1,42 @@
+//
+//  VoodooPS2SMBusDevice.hpp
+//  VoodooPS2Trackpad
+//
+//  Created by Gwydien on 9/13/24.
+//  Copyright © 2024 Acidanthera. All rights reserved.
+//
+
+#ifndef VoodooPS2SMBusDevice_hpp
+#define VoodooPS2SMBusDevice_hpp
+
+
+#include "../VoodooPS2Controller/ApplePS2MouseDevice.h"
+#include <IOKit/IOCommandGate.h>
+
+#include "VoodooPS2TrackpadCommon.h"
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// ApplePS2SmbusDevice Class Declaration
+//  Synaptics and Elans devices still need resets over PS2. This acts as a
+//  PS/2 stub driver that attaches in lieu of the full touchpad driver to reset
+//  on wakeups and sleep. This also prevents other devices attaching and using
+//  the otherwise unused PS/2 interface
+//
+
+class EXPORT ApplePS2SmbusDevice : public IOService {
+    typedef IOService super;
+    OSDeclareDefaultStructors(ApplePS2SmbusDevice);
+public:
+    static ApplePS2SmbusDevice *withReset(bool resetNeeded);
+    
+    bool start(IOService *provider) override;
+    
+private:
+    ApplePS2MouseDevice *_nub {nullptr};
+    bool _resetNeeded {false};
+    
+    IOReturn resetDevice();
+    void powerAction(uint32_t ordinal);
+};
+
+#endif /* VoodooPS2SMBusDevice_hpp */

--- a/VoodooPS2Trackpad/VoodooPS2SMBusDevice.h
+++ b/VoodooPS2Trackpad/VoodooPS2SMBusDevice.h
@@ -2,7 +2,7 @@
 //  VoodooPS2SMBusDevice.hpp
 //  VoodooPS2Trackpad
 //
-//  Created by Gwydien on 9/13/24.
+//  Created by Avery Black on 9/13/24.
 //  Copyright © 2024 Acidanthera. All rights reserved.
 //
 

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -210,6 +210,7 @@ IOService* ApplePS2SynapticsTouchPad::probe(IOService * provider, SInt32 * score
         dictionary->setObject("Clickpad", _cont_caps.one_btn_clickpad ?
                               kOSBooleanTrue : kOSBooleanFalse);
         ApplePS2SmbusDevice *smbus = ApplePS2SmbusDevice::withReset(true, dictionary, 0x2C);
+        OSSafeReleaseNULL(dictionary);
         return smbus;
     }
     

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -76,6 +76,10 @@ bool ApplePS2SynapticsTouchPad::init(OSDictionary * dict)
 
 	memset(freeFingerTypes, true, kMT2FingerTypeCount);
 	freeFingerTypes[kMT2FingerTypeUndefined] = false;
+    
+    _smbusCompanion = OSSymbol::withCString(kSmbusCompanion);
+    if (_smbusCompanion == NULL)
+        return false;
 
     // announce version
 	extern kmod_info_t kmod_info;
@@ -200,9 +204,8 @@ IOService* ApplePS2SynapticsTouchPad::probe(IOService * provider, SInt32 * score
     //
     // Attempt to start SMBus Companion. If succesful, attach a stub PS/2 driver.
     //
-    const OSSymbol *symbol = OSSymbol::withCString("VoodooSMBusCompanionDevice");
     IOService *resources = getResourceService();
-    if (_cont_caps.intertouch && resources && resources->getProperty(symbol)) {
+    if (_cont_caps.intertouch && resources && resources->getProperty(_smbusCompanion)) {
         // Helpful information for SMBus drivers
         OSDictionary *dictionary = OSDictionary::withCapacity(2);
         dictionary->setObject("TrackstickButtons", _securepad.trackstick_btns ?
@@ -601,6 +604,12 @@ void ApplePS2SynapticsTouchPad::stop( IOService * provider )
     // Release ACPI provider for PS2M ACPI device
     //
     OSSafeReleaseNULL(_provider);
+    
+    //
+    // Release OSSymbols
+    //
+    
+    OSSafeReleaseNULL(_smbusCompanion);
     
 	super::stop(provider);
 }

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -200,21 +200,17 @@ IOService* ApplePS2SynapticsTouchPad::probe(IOService * provider, SInt32 * score
     //
     // Attempt to start SMBus Companion. If succesful, attach a stub PS/2 driver.
     //
-    if (_cont_caps.intertouch) {
+    const OSSymbol *symbol = OSSymbol::withCString("VoodooSMBusCompanionDevice");
+    IOService *resources = getResourceService();
+    if (_cont_caps.intertouch && resources && resources->getProperty(symbol)) {
         // Helpful information for SMBus drivers
         OSDictionary *dictionary = OSDictionary::withCapacity(2);
         dictionary->setObject("TrackstickButtons", _securepad.trackstick_btns ?
                               kOSBooleanTrue : kOSBooleanFalse);
         dictionary->setObject("Clickpad", _cont_caps.one_btn_clickpad ?
                               kOSBooleanTrue : kOSBooleanFalse);
-        
-        IOReturn ret = _device->startSMBusCompanion(dictionary, 0x2C);
-        OSSafeReleaseNULL(dictionary);
-        
-        if (ret == kIOReturnSuccess) {
-            ApplePS2SmbusDevice *smbus = ApplePS2SmbusDevice::withReset(true);
-            return smbus;
-        }
+        ApplePS2SmbusDevice *smbus = ApplePS2SmbusDevice::withReset(true, dictionary, 0x2C);
+        return smbus;
     }
     
     _device = 0;

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
@@ -315,7 +315,6 @@ private:
     uint64_t keytime {0};
     UInt16 keycode {0};
     bool ignoreall {false};
-    bool otherBusInUse {false}; // Trackpad being used over SMBus/I2C
 #ifdef SIMULATE_PASSTHRU
 	UInt32 trackbuttons {0};
 #endif
@@ -376,8 +375,7 @@ private:
 
 public:
     bool init( OSDictionary * properties ) override;
-    ApplePS2SynapticsTouchPad * probe( IOService * provider,
-                                               SInt32 *    score ) override;
+    IOService * probe( IOService * provider, SInt32 * score ) override;
     bool start( IOService * provider ) override;
     void stop( IOService * provider ) override;
 

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.h
@@ -323,6 +323,8 @@ private:
     int _processusbmouse {true};
     int _processbluetoothmouse {true};
 
+    const OSSymbol* _smbusCompanion {nullptr};
+    
     OSSet* attachedHIDPointerDevices {nullptr};
     
     IONotifier* usb_hid_publish_notify {nullptr};     // Notification when an USB mouse HID device is connected


### PR DESCRIPTION
Add support to ApplePS2SynapticTouchpad to create SMBus companion devices. This means that VoodooRMI will not start until VoodooPS2 is done probing and detects that the touchpad has SMBus support. A new service (ApplePS2SMBusDevice) is added to prevent other PS/2 drivers attaching and using the PS/2 port on these touchpads.

The case without VoodooSMBus should still work, as VoodooPS2 checks IOResources before attempting to use SMBus for the Synaptic touchpad. The only downside is that there is no way to recover from VoodooRMI failing to start. I originally had the call to create the SMBus companion device in `probe` instead of `start`, but other PS/2 drivers probing would break VoodooRMI due to both drivers trying to use the touchpad at the same time.

This does work (unlike my other attempts), just need some time to do cleanup and to test.

Replaces https://github.com/acidanthera/VoodooPS2/pull/59
Companion PRs:
VoodooSMBus: https://github.com/1Revenger1/VoodooSMBus/pull/4
VoodooRMI: https://github.com/VoodooSMBus/VoodooRMI/pull/183