### PR TITLE
Fixed multiple PS2/SMBus devices attaching

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 VoodooPS2 Changelog
 ============================
+#### v2.3.7
+- Fixed multiple PS2/SMBus devices attaching
+
 #### v2.3.6
 - Lowered macOS requirements to 10.10
 - Added PS/2 stub driver for better VoodooRMI compatibility

--- a/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
+++ b/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp
@@ -213,6 +213,10 @@ IOService* ApplePS2SynapticsTouchPad::probe(IOService * provider, SInt32 * score
         dictionary->setObject("Clickpad", _cont_caps.one_btn_clickpad ?
                               kOSBooleanTrue : kOSBooleanFalse);
         ApplePS2SmbusDevice *smbus = ApplePS2SmbusDevice::withReset(true, dictionary, 0x2C);
+        
+        // gIOMatchCategoryKey is necessary to prevent multiple services attaching to the PS2 device
+        if (smbus)
+            smbus->setProperty(gIOMatchCategoryKey, getProperty(gIOMatchCategoryKey));
         OSSafeReleaseNULL(dictionary);
         return smbus;
     }


### PR DESCRIPTION
gIOMatchCategoryKey is used to check if matching has already occurred.

Fixes https://github.com/VoodooSMBus/VoodooRMI/issues/188